### PR TITLE
Add CI tests for common episode meta errors

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Check file sizes
       run: |
         for episode in _episodes/*.md; do
-          length=$(grep 'length:' "$episode" | awk '{print $2}' | sed 's/"//g');
-          file=$(grep 'file:' "$episode" | sed -e 's/^file: //' -e 's/"//g');
+          length=$(grep 'length:' "$episode" | head -n1 | awk '{print $2}' | sed 's/"//g')
+          file=$(grep 'file:' "$episode" | head -n1 | sed -e 's/^file: //' -e 's/"//g')
           size=$(curl --head -s "$file" | grep content-length | awk '{print $2}' | sed 's/\r//')
           if [ $size -ne $length ]; then
             echo "$(basename "$episode"): ${length}b (reported) != ${size}b (actual)"

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -19,10 +19,18 @@ jobs:
         url: https://rustacean-station.org' \
                _config.yml
         bundle exec jekyll build
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '2.x'
     - name: Check dates
       run: |
-        for date in $(grep -h date _episodes/*.md | sed 's/^date: //'); do
-          date "--date=$date";
+        pip install pytz ciso8601
+        for episode in _episodes/*.md; do
+          date=$(grep 'date:' "$episode" | head -n1 | sed 's/^date: //')
+          if ! python2 -c "import ciso8601; ciso8601.parse_rfc3339('$date');"; then
+            echo "$episode: bad date '$date'"
+            exit 1
+          fi
         done
     - name: Check file sizes
       run: |
@@ -35,9 +43,6 @@ jobs:
             exit 1
           fi
         done
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '2.x'
     - name: Validate feed
       run: |
         # Fix Ubuntu MIME type for RSS

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -7,18 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-ruby@v1
-      with:
-        ruby-version: '2.x'
-    - name: Install dependencies
-      run: bundle install
-    - name: Build site and feed
-      run: |
-        # have site.url produce a valid value
-        sed -i -e '/^collections:/i \
-        url: https://rustacean-station.org' \
-               _config.yml
-        bundle exec jekyll build
     - uses: actions/setup-python@v1
       with:
         python-version: '2.x'
@@ -43,6 +31,18 @@ jobs:
             exit 1
           fi
         done
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.x'
+    - name: Install dependencies
+      run: bundle install
+    - name: Build site and feed
+      run: |
+        # have site.url produce a valid value
+        sed -i -e '/^collections:/i \
+        url: https://rustacean-station.org' \
+               _config.yml
+        bundle exec jekyll build
     - name: Validate feed
       run: |
         # Fix Ubuntu MIME type for RSS

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,54 @@
+name: Jekyll site CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.x'
+    - name: Install dependencies
+      run: bundle install
+    - name: Build site and feed
+      run: |
+        # have site.url produce a valid value
+        sed -i -e '/^collections:/i \
+        url: https://rustacean-station.org' \
+               _config.yml
+        bundle exec jekyll build
+    - name: Check dates
+      run: |
+        for date in $(grep -h date _episodes/*.md | sed 's/^date: //'); do
+          date "--date=$date";
+        done
+    - name: Check file sizes
+      run: |
+        for episode in _episodes/*.md; do
+          length=$(grep 'length:' "$episode" | awk '{print $2}' | sed 's/"//g');
+          file=$(grep 'file:' "$episode" | sed -e 's/^file: //' -e 's/"//g');
+          size=$(curl --head -s "$file" | grep content-length | awk '{print $2}' | sed 's/\r//')
+          if [ $size -ne $length ]; then
+            echo "$(basename "$episode"): ${length}b (reported) != ${size}b (actual)"
+            exit 1
+          fi
+        done
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '2.x'
+    - name: Validate feed
+      run: |
+        # Fix Ubuntu MIME type for RSS
+        sudo sed -i 's@application/x-rss+xml@application/rss+xml@' /etc/mime.types
+        cp _site/podcast.rss validate.rss
+        # https://github.com/rubys/feedvalidator/issues/16
+        sed -i -e 's/https:/http:/g' \
+               -e '/rel="self"/ s@href="[^"]*"@href="file://'"$(pwd)"'/validate.rss"@' \
+               -e '/xmlns:content/a \
+                    xml:base="https://rustacean-station.org"' \
+               validate.rss
+        git clone git://github.com/rubys/feedvalidator.git
+        cd feedvalidator
+        python2 src/demo.py ../validate.rss

--- a/000-template.md
+++ b/000-template.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: (fill me in with the episode's title)
-date: (fill me in with today's date in ISO 8601 format, e.g. "2015-05-15T16:00:00+00:00")
+date: (fill me in with today's date in RFC 3339 format, e.g. "2015-05-15T16:00:00+00:00")
 file: https://audio.rustacean-station.org/file/rustacean-station/(fill me in with the episode mp3 filename)
 duration: (fill in with audio length, HH:MM:SS, e.g. "43:21")
 length: (fill in with audio size in bytes, e.g. "12345678")

--- a/000-template.md
+++ b/000-template.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: (fill me in with the episode's title)
-date: (fill me in with today's date in ISO 8601 format, e.g. "2015-05-15T16:00:00+0000")
+date: (fill me in with today's date in ISO 8601 format, e.g. "2015-05-15T16:00:00+00:00")
 file: https://audio.rustacean-station.org/file/rustacean-station/(fill me in with the episode mp3 filename)
 duration: (fill in with audio length, HH:MM:SS, e.g. "43:21")
 length: (fill in with audio size in bytes, e.g. "12345678")

--- a/_episodes/001-ruma.md
+++ b/_episodes/001-ruma.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Ruma and the Matrix Communication Protocol: An Interview with Jimmy Cuadra"
-date: 2019-08-08T11:45:00+0000
+date: 2019-08-08T11:45:00+00:00
 file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e001-ruma-matrix-jimmy-cuadra.mp3
 duration: "1:03:29" #audio length in min
 length: "60946851" #filesize in byte

--- a/_episodes/002-colorado-gold-rust.md
+++ b/_episodes/002-colorado-gold-rust.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Organizing Colorado Gold Rust: An interview with conference founder J Haigh"
-date: 2019-08-25T17:00:00+0000
+date: 2019-08-25T17:00:00+00:00
 file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e002-colorado-gold-rust.mp3
 duration: "0:28:06" #audio length in min
 length: "26982651" #filesize in byte

--- a/_episodes/003-rust-1.37.0.md
+++ b/_episodes/003-rust-1.37.0.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "What's New in Rust 1.37"
-date: 2019-08-31T17:30:00+0000
+date: 2019-08-31T17:30:00+00:00
 file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e003-rust-1.37.0.mp3
 duration: "0:33:18" #audio length
 length: "26728938" #filesize in byte

--- a/_episodes/004-rust-in-production-armin-ronacher.md
+++ b/_episodes/004-rust-in-production-armin-ronacher.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Rust in Production: An Interview with Armin Ronacher"
-date: 2019-09-17T18:00:00+0000
+date: 2019-09-17T18:00:00+00:00
 file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e004-rust-in-production-armin-ronacher.mp3
 duration: "01:02:25" #audio length
 length: "44940667" #filesize in byte

--- a/_episodes/005-rust-1.38.0.md
+++ b/_episodes/005-rust-1.38.0.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "What's new in Rust 1.38"
-date: 2019-10-14T19:50:00+0000
+date: 2019-10-14T19:50:00+00:00
 file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e005-rust-1.38.0.mp3
 duration: "34:03" #audio length
 length: "24517728" #filesize in byte

--- a/_episodes/006-rust-1.39.0.md
+++ b/_episodes/006-rust-1.39.0.md
@@ -4,7 +4,7 @@ title: "What's New in Rust 1.39"
 date: 2019-11-26T18:00:00+0000
 file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e006-rust-1.39.0.mp3
 duration: "43:03"
-length: "30996753"
+length: "30996793"
 reddit: https://www.reddit.com/r/rust/comments/e20uqy/rustacean_station_podcast_whats_new_in_rust_139/
 
 # preserve guid despire renaming the file

--- a/_episodes/006-rust-1.39.0.md
+++ b/_episodes/006-rust-1.39.0.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "What's New in Rust 1.39"
-date: 2019-11-26T18:00:00+0000
+date: 2019-11-26T18:00:00+00:00
 file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e006-rust-1.39.0.mp3
 duration: "43:03"
 length: "30996793"

--- a/_episodes/007-zola.md
+++ b/_episodes/007-zola.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Creating Static Sites in Rust with Vincent Prouillet"
-date: 2019-12-19T23:00:00+0000
+date: 2019-12-19T23:00:00+00:00
 file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e007-zola-vincent-prouillet.mp3
 duration: "54:24"
 length: "52224834"


### PR DESCRIPTION
The following checks are added:

 - That the page builds
 - That the audio file is available and of the right size
 - That the dates are all valid RFC 3339 (~= ISO 8601, but stricter)
 - That the generated podcast.rss is a valid RSS feed

The meta for e006 is updated to have the correct file size, and all dates have been updated to match the stricter RFC 3339 format.