### PR TITLE
Add a table-of-contents to multi-part episode transcripts

### DIFF
--- a/_transcripts/009-jan-lucio.md
+++ b/_transcripts/009-jan-lucio.md
@@ -3,6 +3,11 @@ title: "Double Feature: Jan-Erik Rediger on RustFest & Lucio Franco on the Tonic
 file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e009-rustfest-jan-erik-rediger.mp3
 ---
 
+* placeholder to generate bulleted TOC
+{:toc}
+
+#### Jan-Erik Rediger on RustFest
+
 __Ben Striegel__: Welcome to Rustacean Station podcast. I'm here with a micro-
 interview from RustFest. We're here in a cafeteria, using borrowed audio
 equipment. So I apologize for the audio quality. You might hear people walking
@@ -220,6 +225,8 @@ __Ben__: All right. Well, thanks a lot, Jan-Erik.
 __Jan-Erik__: Thank you.
 
 (Musical break)
+
+#### Lucio Franco on the Tonic gRPC framework
 
 __Ben__: Welcome to Rustacean Station, live in a sense, from RustFest. Everyone
 just says live. I can't just not say live. I've always wanted to do that. So I

--- a/_transcripts/012-pietro-pascal-santiago.md
+++ b/_transcripts/012-pietro-pascal-santiago.md
@@ -3,6 +3,11 @@ title: "RustFest Interviews Triple Feature: Rust Release Engineering; Developing
 file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e012-rustfest-pietro-pascal-santiago.mp3
 ---
 
+* placeholder to generate bulleted TOC
+{:toc}
+
+#### Pietro Albini on Rust Release Engineering
+
 __Ben Striegel__: Welcome to Rustacean Station, here at Rust 2019 from
 Barcelona. I am here with Pietro Albini.
 
@@ -316,6 +321,8 @@ __Ben__: Awesome. Great. Thanks so much for talking to us.
 __Pietro__: Thank you for asking.
 
 (Musical break)
+
+#### Pascal Hertleif on Developing the Developer Tools
 
 __Ben__: Welcome to the Rustacean Station Podcast. I am Ben Striegel, live at
 RustFest. I am here right now, in our improvised studio, with Pascal Hertleif.
@@ -635,6 +642,8 @@ __Ben__: See you around.
 __Pascal__: See you.
 
 (Musical break)
+
+#### Santiago Pastorino on Rust in Latin America
 
 __Ben__: Okay. Welcome to Rustacean Station. It is day four of RustFest. We get
 to have our improvised studio here, so please bear with us with any audio

--- a/style.css
+++ b/style.css
@@ -186,6 +186,15 @@ ul { list-style-type: square; }
 		background-color: #f1f1f1;
 		padding: 0.1em 0.2em;
 	}
+	.episode.transcript .body h4 {
+		margin-top: 3em;
+		font-size: 1em;
+		text-align: center;
+	}
+	.episode.transcript > .detail {
+		margin-bottom: 2em;
+	}
+
 
 #wrapper > footer {
        border-top: 1px solid #AAA;


### PR DESCRIPTION
To make it easier to jump to the second or third interview in a multi-part episode, add an auto-generated table of contents to a few episodes.

Includes CSS changes to give the TOC and headers a small separation.