### PR TITLE
fail gracefully on 404 during mp3 length check

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -30,7 +30,11 @@ jobs:
         for episode in _episodes/*.md; do
           length=$(grep 'length:' "$episode" | head -n1 | awk '{print $2}' | sed 's/"//g')
           file=$(grep 'file:' "$episode" | head -n1 | sed -e 's/^file: //' -e 's/"//g')
-          size=$(curl --head -s "$file" | grep content-length | awk '{print $2}' | sed 's/\r//')
+          size=$(curl --head -f -s "$file" | grep content-length | awk '{print $2}' | sed 's/\r//')
+          if [ -z $size ]; then
+            echo "couldn't get content length of \"$file\""
+            exit 1
+          fi
           if [ $size -ne $length ]; then
             echo "$(basename "$episode"): ${length}b (reported) != ${size}b (actual)"
             exit 1

--- a/_episodes/018-twir-343.md
+++ b/_episodes/018-twir-343.md
@@ -1,9 +1,9 @@
 ---
 title: "This Week in Rust - Issue 343"
 date: 2020-06-16T14:30:00Z
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-06-16.mp3 
+file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-06-16.mp3
 duration: "06:04"
-length: "124"
+length: "8743623"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
 

--- a/_transcripts/018-twir-343.md
+++ b/_transcripts/018-twir-343.md
@@ -1,6 +1,6 @@
 ---
 title: "This Week in Rust - Issue 343"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-06-16.mp3 
+file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-06-16.mp3
 ---
 
 __Nell Shamrell-Harrington__: Hello everyone! Welcome back to the This Week in Rust podcast, covering issue 343 of the This Week in Rust newsletter.


### PR DESCRIPTION
Instead of using the content-length of the 404 page, fail the check with
a helpful error message.