### PR TITLE
Transcript links

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -63,20 +63,6 @@ jobs:
             echo "$(basename "$transcript"): no matching episode"
             exit 1
           fi
-
-          title=$(grep -E "^title:" "$transcript")
-          file=$(grep -E "^file:" "$transcript")
-          if [[ -z $title || -z $file ]]; then
-            echo "$transcript: missing front matter"
-            exit 1
-          fi
-
-          etitle=$(grep -E "^title:" "$episode")
-          efile=$(grep -E "^file:" "$episode")
-          if [[ $title != $etitle || $file != $efile ]]; then
-            echo "$transcript: front matter does not match episode front matter"
-            exit 1
-          fi
         done
   feed:
     runs-on: ubuntu-latest

--- a/_includes/util.html
+++ b/_includes/util.html
@@ -1,0 +1,5 @@
+{%- if page.episode != nil -%}
+{%- assign episode = site.episodes | where:"path",page.episode | first -%}
+{%- else -%}
+{%- assign episode = page -%}
+{%- endif -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,11 +25,12 @@
 			/>
 		</a>
 		</h1>
-		{% if page.file %}
+		{%- include util.html -%}
+		{%- if episode.file -%}
 		<div id="player">
-		<audio src="https://dts.podtrac.com/redirect.mp3/{{ page.file | replace_first: "https://", "" }}" controls></audio>
+		<audio src="https://dts.podtrac.com/redirect.mp3/{{ episode.file | replace_first: "https://", "" }}" controls></audio>
 		</div>
-		{% endif %}
+		{%- endif -%}
 		<div id="wrapper">
 			{{ content }}
 			<footer>

--- a/_layouts/episode.html
+++ b/_layouts/episode.html
@@ -5,17 +5,14 @@ layout: default
 <article class="episode full">
 	<h1>{{ page.title }}</h1>
 	<span class="detail">Posted {{ page.date | date_to_rfc822 }}</span>
-	{% if page.reddit %}
+	{%- if page.reddit -%}
 	<span class="detail"><a href="{{ page.reddit }}">Discussion on Reddit</a></span>
-	{% endif %}
-	{% capture pagefn %}{{ page.path | remove_first: page.collection | remove_first: '_/' }}{% endcapture %}
-	{% for trans in site.transcripts %}
-	{% capture transfn %}{{ trans.path | remove_first: trans.collection | remove_first: '_/' }}{% endcapture %}
-	{% if transfn == pagefn %}
-	  <span class="detail"><a href="{{ trans.url }}">Episode Transcript</a></span>
-	  {% break %}
-	{% endif %}
-	{% endfor %}
+	{%- endif -%}
+
+	{%- assign transcript = site.transcripts | where:"episode",page.path | first -%}
+	{%- if transcript -%}
+	  <span class="detail"><a href="{{ transcript.url }}">Episode Transcript</a></span>
+	{%- endif -%}
 
 	<div class="body">
 	{{ content }}

--- a/_layouts/transcript.html
+++ b/_layouts/transcript.html
@@ -8,7 +8,7 @@ layout: default
 	{% for ep in site.episodes %}
 	{% capture epfn %}{{ ep.path | remove_first: ep.collection | remove_first: '_/' }}{% endcapture %}
 	{% if epfn == pagefn %}
-	  <span class="detail"><a href="{{ ep.url }}">Back to Episode Page</a></span>
+	  <span class="detail"><a href="{{ ep.url }}">Episode Page with Show Notes</a></span>
 	  {% break %}
 	{% endif %}
 	{% endfor %}

--- a/_layouts/transcript.html
+++ b/_layouts/transcript.html
@@ -2,17 +2,10 @@
 layout: default
 ---
 
+{%- include util.html -%}
 <article class="episode full transcript">
-	<h1>{{ page.title }}</h1>
-	{% capture pagefn %}{{ page.path | remove_first: page.collection | remove_first: '_/' }}{% endcapture %}
-	{% for ep in site.episodes %}
-	{% capture epfn %}{{ ep.path | remove_first: ep.collection | remove_first: '_/' }}{% endcapture %}
-	{% if epfn == pagefn %}
-	  <span class="detail"><a href="{{ ep.url }}">Episode Page with Show Notes</a></span>
-	  {% break %}
-	{% endif %}
-	{% endfor %}
-
+	<h1>{{ episode.title }}</h1>
+	<span class="detail"><a href="{{ episode.url }}">Episode Page with Show Notes</a></span>
 	<div class="body">
 	{{ content }}
 	</div>

--- a/_transcripts/004-rust-in-production-armin-ronacher.md
+++ b/_transcripts/004-rust-in-production-armin-ronacher.md
@@ -1,6 +1,5 @@
 ---
-title: "Rust in Production: An Interview with Armin Ronacher"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e004-rust-in-production-armin-ronacher.mp3
+episode: _episodes/004-rust-in-production-armin-ronacher.md
 ---
 
 __Ben Striegel__: Howdy, folks. You're listening to Rustacean Station. Today's

--- a/_transcripts/005-rust-1.38.0.md
+++ b/_transcripts/005-rust-1.38.0.md
@@ -1,6 +1,5 @@
 ---
-title: "What's new in Rust 1.38"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e005-rust-1.38.0.mp3
+episode: _episodes/005-rust-1.38.0.md
 ---
 
 __Ben Striegel__: Welcome once again, ladies and gentlemen, to Rustacean

--- a/_transcripts/006-rust-1.39.0.md
+++ b/_transcripts/006-rust-1.39.0.md
@@ -1,7 +1,9 @@
 ---
-title: "What's New in Rust 1.39"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e006-rust-1.39.0.mp3
+episode: _episodes/006-rust-1.39.0.md
 ---
+
+{%- include util.html -%}
+[episode]: {{episode.url}}
 
 __Jon Gjengset__: Hello, Ben.
 
@@ -568,7 +570,7 @@ I've seen plenty of other libraries start to support `async-std`, there's a
 really good developing ecosystem there.
 
 __Jon__: I thought one thing that was cool from that blog post, which we'll link
-in the show notes, was this `wasm_bindgen_futures` crate. So this is a crate
+in the [show notes][episode], was this `wasm_bindgen_futures` crate. So this is a crate
 that lets you turn Rust— it lets you bridge between Rust futures and JavaScript
 promises. So if you're using wasm, it lets you— I don't know exactly how the
 binding works, but it lets you wait on JavaScript promises in Rust and let you
@@ -717,7 +719,7 @@ __Ben__: You do a lot of work for the back end of this podcast. And I definitely
 appreciate not having to ever worry about. In my end, I just kind of make
 release notes, and I push the PR and it's done, and I am so grateful for all of
 that. And now the website looks very, very nice. I have really enjoyed—
-especially with the— you have little like, links for in the release notes. You
+especially with the— you have little like, links for in the [release notes][episode]. You
 can click on a time stamp, and it will jump to an embedded player, and actually
 goes to the time of the whatever I'm talking about. And so it's actually really
 nice. It's super great.
@@ -736,7 +738,7 @@ literally as easy as kind of, just like, flinging an audio file at us that has
 to do with Rust. It could be an interview with somebody that you know, that's
 doing cool Rust stuff, or really anything at all. This is a crowdsourced,
 community-based podcast, and so if you have an idea for a thing, you could even
-just hit us up on any of the venues that are linked in the release notes. We
+just hit us up on any of the venues that are linked in the [release notes][episode]. We
 have a Discord, a Twitter. Give us an idea. Introduce us to somebody that you
 know, that you think is doing cool things, and maybe we'll get around to
 interviewing them. So, yeah, that's the whole point of this lovely, lovely

--- a/_transcripts/007-zola.md
+++ b/_transcripts/007-zola.md
@@ -1,7 +1,9 @@
 ---
-title: "Creating Static Sites in Rust with Vincent Prouillet"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e007-zola-vincent-prouillet.mp3
+episode: _episodes/007-zola.md
 ---
+
+{%- include util.html -%}
+[episode]: {{episode.url}}
 
 __Ben Striegel__: Howdy, folks. You're listening to Rustacean Station. Today's
 episode is hosted by one of our volunteers. That's kind of what this whole
@@ -750,7 +752,7 @@ the issues. If you get confused with some documentation. Don't hesitate to do
 pull requests, that's always helpful. Anything can help basically.
 
 __Jeremy__: Cool we'll be sure to get the links to the forum and to Zola and
-your other projects as well into the show notes.
+your other projects as well into the [show notes][episode].
 
 Finally to wrap up, is there anything else that you'd like to mention or think
 that we should have talked about?
@@ -774,7 +776,7 @@ issue tracker. I don't really use any social network. I have a twitter account
 but it's fairly silent, I'd say. I don't really look at it very often. I think
 The best way would be GitHub issues, probably.
 
-__Jeremy__: And, as we mentioned before, we'll get a link to that in the notes.
+__Jeremy__: And, as we mentioned before, we'll get a link to that in the [notes][episode].
 
 __Vincent__: Okay, perfect.
 

--- a/_transcripts/008-oli-miri.md
+++ b/_transcripts/008-oli-miri.md
@@ -1,6 +1,5 @@
 ---
-title: "Compile-Time Evaluation, Interpreted Rust, and UB Sanitizing: Talking to Oliver Scherer about Miri"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e008-miri-oli-obk.mp3
+episode: _episodes/008-oli-miri.md
 ---
 
 __Ben Striegel__: All right, let me improvise an intro. Welcome to Rustacean

--- a/_transcripts/009-jan-lucio.md
+++ b/_transcripts/009-jan-lucio.md
@@ -1,6 +1,5 @@
 ---
-title: "Double Feature: Jan-Erik Rediger on RustFest & Lucio Franco on the Tonic gRPC framework"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e009-rustfest-jan-erik-rediger.mp3
+episode: _episodes/009-jan-lucio.md
 ---
 
 * placeholder to generate bulleted TOC

--- a/_transcripts/010-rust-1.40.0.md
+++ b/_transcripts/010-rust-1.40.0.md
@@ -1,6 +1,5 @@
 ---
-title: "What's New in Rust 1.40"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e010-rust-1.40.0.mp3
+episode: _episodes/010-rust-1.40.0.md
 ---
 
 __Jon Gjengset__: Hello, Ben.

--- a/_transcripts/011-jake-yoshua-stjepan.md
+++ b/_transcripts/011-jake-yoshua-stjepan.md
@@ -1,6 +1,5 @@
 ---
-title: "RustFest Interviews Triple Feature: Rust for AAA Game Development; Async Foundations with `async-std`; and Powerful Concurrency Primitives with `crossbeam`"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e011-rustfest-jake-yoshua-stjepan.mp3
+episode: _episodes/011-jake-yoshua-stjepan.md
 ---
 
 * placeholder to generate bulleted TOC

--- a/_transcripts/012-pietro-pascal-santiago.md
+++ b/_transcripts/012-pietro-pascal-santiago.md
@@ -1,6 +1,5 @@
 ---
-title: "RustFest Interviews Triple Feature: Rust Release Engineering; Developing the Developer Tools; Rust in Latin America"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e012-rustfest-pietro-pascal-santiago.mp3
+episode: _episodes/012-pietro-pascal-santiago.md
 ---
 
 * placeholder to generate bulleted TOC

--- a/_transcripts/013-rust-1.41.0.md
+++ b/_transcripts/013-rust-1.41.0.md
@@ -1,7 +1,9 @@
 ---
-title: "What's New in Rust 1.41"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e013-rust-1.41.0.mp3
+episode: _episodes/013-rust-1.41.0.md
 ---
+
+{%- include util.html -%}
+[episode]: {{episode.url}}
 
 __Jon Gjengset__: All right, Ben, how about we get started by applauding
 ourselves this time? For once we are recording the episode the day after
@@ -426,7 +428,7 @@ the lang team, I guess, to sit down and figure out what are the language
 guarantees that we give you for this type.
 
 You'll notice there's a— I don't think it's linked in the release notes,
-but we'll do it in the notes for this episode, which is— there's something
+but we'll do it in the [notes][episode] for this episode, which is— there's something
 called the Rust Unsafe Code Guidelines Working Group, which are— they're
 basically going through all of the various things you might care about
 in unsafe and figuring out, what are the actual rules? Like rules around
@@ -785,7 +787,7 @@ so many things that are being done on a volunteer basis. You can't just be
 like "you're fired if you don't get this done," like, no, you're a volunteer,
 what are they going to do? In this case, it's kind of like, again, polishing
 up various things from previous years. But people should read it— we'll
-leave a link to it in the release notes here.
+leave a link to it in the [release notes][episode] here.
 
 __Jon__: Yeah, I think I was a big fan of the direction they chose for this
 year. Even though it's relatively high-level, I think it's a good direction

--- a/_transcripts/014-rust-1.42-1.43.md
+++ b/_transcripts/014-rust-1.42-1.43.md
@@ -1,7 +1,9 @@
 ---
-title: "What's New in Rust 1.42 and 1.43"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e014-rust-1.42-1.43.mp3
+episode: _episodes/014-rust-1.42-1.43.md
 ---
+
+{%- include util.html -%}
+[episode]: {{episode.url}}
 
 __Jon Gjengset__: Hello, Ben. How are you doing?
 
@@ -969,7 +971,7 @@ maybe already is in the prelude but `FromIterator` is not, so there's an
 issue you can look up, which is like "things that are being considered for
 the prelude for the next edition." And it's a pretty interesting read.
 
-__Ben__: Yeah, we'll find that link that for the show notes. And I think now
+__Ben__: Yeah, we'll find that link that for the [show notes][episode]. And I think now
 is the time, if you actually care for these things, to get involved, because
 the idea is probably by later on this year to have an idea of what's going
 to change in the next edition and then spent 2021 actually doing it.

--- a/_transcripts/015-twir-339.md
+++ b/_transcripts/015-twir-339.md
@@ -1,7 +1,9 @@
 ---
-title: "This Week in Rust - Issue 339"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-05-19.mp3
+episode: _episodes/015-twir-339.md
 ---
+
+{%- include util.html -%}
+[episode]: {{episode.url}}
 
 __Jon Gjengset__: Hello fellow Rustacean!
 
@@ -11,7 +13,7 @@ __Nell Shamrell-Harrington__: Hello everyone! This is the first episode of the T
 
 Every week, this podcast will highlight a few items from the This Week in Rust newsletter. Eventually, I hope to have guests each week to discuss some key stories and announcements from the newsletter, as well as occasional deep dive episodes into some aspect of Rust and the Rust community.
 
-This Week in Rust is usually published on Tuesdays and emailed out on Wednesdays. I will most likely be recording this podcast on Monday night so a link to it can be included in the newsletter. So if you want a chance for your story to be highlighted, make sure to get your pull requests in early each week. I am linking to the This Week in Rust GitHub repo in the show notes.
+This Week in Rust is usually published on Tuesdays and emailed out on Wednesdays. I will most likely be recording this podcast on Monday night so a link to it can be included in the newsletter. So if you want a chance for your story to be highlighted, make sure to get your pull requests in early each week. I am linking to the This Week in Rust GitHub repo in the [show notes][episode].
 
 Let’s dive into this week’s highlights.
 
@@ -29,7 +31,7 @@ Finally, I’ve also personally really been enjoying Rust developers streaming t
 
 If you have always wanted to contribute to Open Source projects, but don’t know where to start, look in the Call for Participation section for tasks that you can pick up and get started with. This week we feature an issue from the clap project - the command line argument parser for Rust - which has a mentor available to help. We also have a couple of issues from the keikan project - an elegant rendering engine written in Rust. Both of these projects are great opportunities to get involved with Open Source software and the Rust language.
 
-The RFC - or request for comment process - is at the core of how the Rust project operates. This week, the RFC which proposes transitioning to Rust-analyzer as our official Language Server Protocol (or LSP) implementation is in final comment period, which means it is reaching a decision soon. If you have an opinion on this, now is the time to express it in that RFC. The link to it is also in the show notes. 
+The RFC - or request for comment process - is at the core of how the Rust project operates. This week, the RFC which proposes transitioning to Rust-analyzer as our official Language Server Protocol (or LSP) implementation is in final comment period, which means it is reaching a decision soon. If you have an opinion on this, now is the time to express it in that RFC. The link to it is also in the [show notes][episode].
 
 There is also a new RFC about reading into uninitialized buffers. This one focuses on the Read trait - specifically how when you use it it requires that the buffer passed to its various methods be pre-initialized even though the contents will be immediately overwritten. This RFC proposes an interface to allow implementors and consumers of Read types to robustly and soundly work with uninitialized buffers. If you are curious about this, if you have opinions, thoughts, or questions, definitely head to that RFC and comment.
 

--- a/_transcripts/016-twir-340.md
+++ b/_transcripts/016-twir-340.md
@@ -1,9 +1,8 @@
 ---
-title: "This Week in Rust - Issue 340"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-05-26.mp3
+episode: _episodes/016-twir-340.md
 ---
 
-__Nell Shamrell-Harrington__: Hello everyone! Thank you to all who listened to the first episode last week, it’s great to bring you another one this week for This Week in Rust Issue number 340. 
+__Nell Shamrell-Harrington__: Hello everyone! Thank you to all who listened to the first episode last week, it’s great to bring you another one this week for This Week in Rust Issue number 340.
 
 I’m Nell Shamrell-Harrington, lead editor of This Week in Rust, and an engineer on the Rust team at Mozilla. Every week this podcast highlights a few of the stories that week’s issue of This Week in Rust.
 

--- a/_transcripts/017-twir-341-342.md
+++ b/_transcripts/017-twir-341-342.md
@@ -1,6 +1,5 @@
 ---
-title: "This Week in Rust - Issue 341 and 342"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-06-09.mp3
+episode: _episodes/017-twir-341-342.md
 ---
 
 __Nell Shamrell-Harrington__: Hello everyone and welcome back to the This Week in Rust podcast! This episode will cover both last week and this week’s issues of the newsletter.
@@ -33,7 +32,7 @@ Speaking of videos, issue 341 of This Week in Rust also includes a video on usin
 
 Moving on to this week’s issue: issue number 342. Here are the highlights.
 
-This week Rust 1.44.0 was announced! Rust 1.44 is a small release, with cargo tree integrated into Cargo itself and support for async/await in no_std contexts. Additionally, in the announcement, the Rust core team also encouraged everyone to take the time to learn about racial inequality and to support the Black Lives Matter movement. 
+This week Rust 1.44.0 was announced! Rust 1.44 is a small release, with cargo tree integrated into Cargo itself and support for async/await in no_std contexts. Additionally, in the announcement, the Rust core team also encouraged everyone to take the time to learn about racial inequality and to support the Black Lives Matter movement.
 
 Stack Overflow recently released the results of its 2020 survey and, for the fifth year in a row, Rust was named the most loved programming language! Chances are, if you’re listening to this podcast, you already love Rust. But if you find yourself needing to help someone else understand it, David Ramel’s article called “So What’s Up with Microsofts’s (and Everyone Else’s) Love of Rust” will help you out. Additionally, Ryan Donovan’s article “Why the developers who use Rust love it so much” highlights several quotes from members of the Rust community explaining what the language means to them.
 
@@ -49,13 +48,13 @@ To see even more Rustaceans in action, check out this week’s featured videos. 
 
 If you have always wanted to contribute to Rust Open Source projects, but don’t know where to start, look in the Call for Participation section for tasks that you can pick up and get started with. Issue 341 featured several issues from the ruma-events project — this project contains serializable types in the Matrix specification that can be shared by client and server code. Additionally, Alex Dukhno is looking for contributors to help with a database management system project called, appropriately, database.
 
-This week in issue 342 we feature several issues from the maud project. Maud is an HTML template engine for Rust which is implemented as a macro which compiles your markup to specialized Rust code. 
+This week in issue 342 we feature several issues from the maud project. Maud is an HTML template engine for Rust which is implemented as a macro which compiles your markup to specialized Rust code.
 
 Check these issues out today and get your pull requests in!
 
 This week is a quieter week for RFCs — no RFCs were approved this week, no RFCS were proposed this week, and no RFCs are currently in final comment period. There are, however, several tracking issues and pull requests that are in final comment period, all with a disposition to merge. Take a look at that section of the newsletter for all of the details.
 
-As for events, we continue to see most events being held online during the ongoing COVID-19 pandemic. You can tune in from anywhere to online meetups in Dallas, TX, Wroclaw, PL, Berlin, San Diego, CA, Zurich, CH, and Turin, IT. 
+As for events, we continue to see most events being held online during the ongoing COVID-19 pandemic. You can tune in from anywhere to online meetups in Dallas, TX, Wroclaw, PL, Berlin, San Diego, CA, Zurich, CH, and Turin, IT.
 
 There are also a few meetups that may be held in person — including in Columbus, OH, Lehi, UT, Vancouver, BC, and Durham, NC. Please make sure to check the meetup pages for each of these meetups before you go in case they are moved online.
 

--- a/_transcripts/018-twir-343.md
+++ b/_transcripts/018-twir-343.md
@@ -1,13 +1,15 @@
 ---
-title: "This Week in Rust - Issue 343"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-06-16.mp3
+episode: _episodes/018-twir-343.md
 ---
+
+{%- include util.html -%}
+[episode]: {{episode.url}}
 
 __Nell Shamrell-Harrington__: Hello everyone! Welcome back to the This Week in Rust podcast, covering issue 343 of the This Week in Rust newsletter.
 
 As always, I’m Nell Shamrell-Harrington, lead editor of This Week in Rust and a Sr. Staff Engineer at Mozilla on the Rust team.
 
-This week’s issue starts off with several community related announcements. Due to the ongoing COVID-19 pandemic, several Rust events planned at the beginning of the year had to be altered. 
+This week’s issue starts off with several community related announcements. Due to the ongoing COVID-19 pandemic, several Rust events planned at the beginning of the year had to be altered.
 
 The Rust community team has published a blog post with an updated listing of Rust events in 2020. Curious about the state of a certain event? Take a look at the blog post for more information.
 
@@ -29,11 +31,11 @@ This week’s call for participation section features a GitHub issue on Rust its
 
 No RFCs were approved this week and no RFCs are in final comment period. However, a new RFC was proposed this week - one to add the Freeze trait to libcore/libstd.
 
-Freeze is a new marker trait, similar to Send and Sync, that is intended to only be implemented for types which have no direct interior mutability, and are therefore safe to place in read only memory. 
+Freeze is a new marker trait, similar to Send and Sync, that is intended to only be implemented for types which have no direct interior mutability, and are therefore safe to place in read only memory.
 
-For more information and to follow the discussion, make sure to go to the RFC link listed in the show notes. 
+For more information and to follow the discussion, make sure to go to the RFC link listed in the [show notes][episode].
 
-A few tracking issues and pull requests are in final comment period this week — one adds Windows system error codes that should map to the input output error kind timed out. And the other takes advantage of changes introduced in Rust 1.41.0 to implement the PartialEq trait on more types. For full details, make sure to take a look at the links in the show notes.
+A few tracking issues and pull requests are in final comment period this week — one adds Windows system error codes that should map to the input output error kind timed out. And the other takes advantage of changes introduced in Rust 1.41.0 to implement the PartialEq trait on more types. For full details, make sure to take a look at the links in the [show notes][episode].
 
 As far as events go, we have several upcoming remote events out of Zurich Switzerland, Turin Italy, Edinburgh [EDIN-BURROW] Scotland, and Berlin Germany. Since they’re online, why not tune into them and meet Rust developers from around the world?
 

--- a/_transcripts/019-twir-344.md
+++ b/_transcripts/019-twir-344.md
@@ -1,9 +1,8 @@
 ---
-title: "This Week in Rust - Issue 344"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-06-23.mp3
+episode: _episodes/019-twir-344.md
 ---
 
-__Nell Shamrell-Harrington__: Hello everyone and welcome to This Week in Rust! As always, I’m Nell Shamrell-Harrington, lead editor of the This Week in Rust newsletter. I’m also Sr. Staff Research Engineer on the Rust team at Mozilla. 
+__Nell Shamrell-Harrington__: Hello everyone and welcome to This Week in Rust! As always, I’m Nell Shamrell-Harrington, lead editor of the This Week in Rust newsletter. I’m also Sr. Staff Research Engineer on the Rust team at Mozilla.
 
 As a reminder, if you write or read a great article on Rust, if you have a Rust job opportunity, or if you have a call for participation for the Rust community, please submit it to This Week in Rust twitter account or the This Week in Rust GitHub repo. We depend on you to help us make each issue valuable to the entire Rust community.
 
@@ -39,7 +38,7 @@ Finally for videos, Felix Klock, also a member of the Rust team at Mozilla, rece
 
 There are many more news stories and blog posts in this week’s issue of This Week in Rust - make sure to check out the newsletter for all of them.
 
-Let’s move onto the Call for Participation section. 
+Let’s move onto the Call for Participation section.
 
 The GitUI project is looking for contributors. GitUI is a blazing fast terminal client for git written in Rust. The maintainers have marked several issues as good first ones and have had good experiences mentoring Rust newcomers.
 
@@ -53,9 +52,9 @@ Unwinding is what happens when a program you are running throws an exception. Wh
 
 Rust does not implement exceptions the way languages like C++ do, but it does support unwinding under two conditions. When rust code panics, it will unwind the stack. Also when Rust is interfacing with another programming language that does implement exceptions — such as C++ — it can call functions in that language to unwind the stack.
 
-Currently, when foreign code — that means code not written in Rust — calls Rust code and the Rust code panics, the foreign code cannot unwind that Rust panic. Likewise, when Rust calls foreign code and that code throws an exception, Rust cannot unwind what happened in that code. 
+Currently, when foreign code — that means code not written in Rust — calls Rust code and the Rust code panics, the foreign code cannot unwind that Rust panic. Likewise, when Rust calls foreign code and that code throws an exception, Rust cannot unwind what happened in that code.
 
-This RFC seeks to change this by defining a new ABI string — an addition to the current ABI. An ABI is an application binary interface — it’s a way for two compiled binaries to interact with each other. The ABI string defined by this RFC makes it safe to unwind C++ frames with a Rust panic and unwind Rust frames with a C++ exception. 
+This RFC seeks to change this by defining a new ABI string — an addition to the current ABI. An ABI is an application binary interface — it’s a way for two compiled binaries to interact with each other. The ABI string defined by this RFC makes it safe to unwind C++ frames with a Rust panic and unwind Rust frames with a C++ exception.
 
 For more details and examples, make sure to read the full RFC.
 
@@ -63,7 +62,7 @@ No RFCs were approved this week, and no RFCs are currently in Final Comment Peri
 
 However, several tracking issues and pull requests are in final comment period. All of them are current labeled as disposition: merge. Let’s go through a few of them.
 
-The first of these adds an implementation that allows a String to be created from a Char type. 
+The first of these adds an implementation that allows a String to be created from a Char type.
 
 Another is a pull request that  stabilizes the leading_trailing_ones feature and will make it a part of Rust 1.46.0 The leading_trailing_ones feature is implemented on an unsized integer, or usize, type. It returns the number of trailing ones in the binary representation of itself.
 

--- a/_transcripts/020-twir-345.md
+++ b/_transcripts/020-twir-345.md
@@ -1,9 +1,8 @@
 ---
-title: "This Week in Rust - Issue 345"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-06-29.mp3
+episode: _episodes/020-twir-345.md
 ---
 
-__Nell Shamrell-Harrington__: Greetings and welcome to another episode of This Week in Rust on the Rustacean Station! As always, I’m Nell Shamrell-Harrington, lead editor of the This Week in Rust newsletter. I’m also a Sr. Staff Research Engineer on the Rust team at Mozilla. 
+__Nell Shamrell-Harrington__: Greetings and welcome to another episode of This Week in Rust on the Rustacean Station! As always, I’m Nell Shamrell-Harrington, lead editor of the This Week in Rust newsletter. I’m also a Sr. Staff Research Engineer on the Rust team at Mozilla.
 
 Let’s dive right into some featured stories from This Week in Rust issue number 345 published June 30, 2020.
 
@@ -39,7 +38,7 @@ The third new RFC, “Portable packed SIMD vector types”, concerns, as you can
 
 The final new RFC for this week is titled “Hierarchic anonymous life-time”. It proposes adding into the Rust language the ability to reference struct fields with anonymous lifetimes. There has been quite a bit of discussion on this RFC and I highly recommend you give it a read.
 
-Two RFCs have moved into FCP or Final Comment Period this week. 
+Two RFCs have moved into FCP or Final Comment Period this week.
 
 The first is titled “Inline Constant Expressions and Patterns.” This RFC introduces a new syntax which instructs the compiler to execute the contents of a block at compile time. An inline constant can be used as an expression or anywhere in a pattern where a named constant would be allowed
 

--- a/_transcripts/021-twir-346.md
+++ b/_transcripts/021-twir-346.md
@@ -1,9 +1,8 @@
 ---
-title: "This Week in Rust - Issue 346"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-07-06.mp3
+episode: _episodes/021-twir-346.md
 ---
 
-__Nell Shamrell-Harrington__: Hello and welcome to another episode of This Week in Rust on the Rustacean Station! As always, I’m Nell Shamrell-Harrington, lead editor of This Week in Rust and also a Sr. Staff Research Engineer on the Rust team at Mozilla. 
+__Nell Shamrell-Harrington__: Hello and welcome to another episode of This Week in Rust on the Rustacean Station! As always, I’m Nell Shamrell-Harrington, lead editor of This Week in Rust and also a Sr. Staff Research Engineer on the Rust team at Mozilla.
 
 Let’s dive right into some featured stories from This Week in Rust issue number 346.
 
@@ -33,7 +32,7 @@ The third RFC in final comment period is titled “Inline Assembly.” This RFC 
 
 No RFCs were approved this week.
 
-Moving onto events, it is still so wonderful to see so many meetups from around the world available to attend online. I personally had the pleasure of attending the Rust Dublin meetup last week. One tip on attending these remote meetups — make sure to RSVP on Meetup.com before the meetup starts, that way you will be able to see the Zoom link when the time comes. 
+Moving onto events, it is still so wonderful to see so many meetups from around the world available to attend online. I personally had the pleasure of attending the Rust Dublin meetup last week. One tip on attending these remote meetups — make sure to RSVP on Meetup.com before the meetup starts, that way you will be able to see the Zoom link when the time comes.
 
 There are upcoming remote events in Berlin, San Diego, CA, Turin, IT, and my own hometown of Seattle, WA. Additionally, some meetups are, at this time, planning to meet in person including in Atlanta, GA, Lehi, UT, and Vancouver, BC. As the COVID-19 pandemic is still an evolving situation, please be sure to check the meetup page before you go just in case the meetup is moved to another location or online.
 

--- a/_transcripts/022-twir-347.md
+++ b/_transcripts/022-twir-347.md
@@ -1,9 +1,8 @@
 ---
-title: "This Week in Rust - Issue 347"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-07-14.mp3
+episode: _episodes/022-twir-347.md
 ---
 
-__Nell Shamrell-Harrington__: Hello and welcome to another episode of This Week in Rust on the Rustacean Station! As always, I’m Nell Shamrell-Harrington, lead editor of This Week in Rust and also a Sr. Staff Research Engineer on the Rust team at Mozilla. 
+__Nell Shamrell-Harrington__: Hello and welcome to another episode of This Week in Rust on the Rustacean Station! As always, I’m Nell Shamrell-Harrington, lead editor of This Week in Rust and also a Sr. Staff Research Engineer on the Rust team at Mozilla.
 
 This episode covers This Week in Rust issue #347, published on July 14, 2020.
 
@@ -37,7 +36,7 @@ Additionally, Alexsander Heintz has posted a video intro to Rust and WebAssembly
 
 Moving onto RFCs. One new RFC was proposed this week, titled “Opt-in Stable Trait VTables”. This RFC proposes adding a new attribute to the Rust language called stable_vtable. This RFC is related to how Rust interacts with code written in other languages.. If this RFC is adopted, a user could define a trait that encapsulates runtime behavior, then obtain a pointer of some kind to a foreign implementation of that trait. Check out the RFC for the full discussion.
 
-No RFCs are in Final Comment Period and no RFCs were approved this week. 
+No RFCs are in Final Comment Period and no RFCs were approved this week.
 
 On the Rust job front, LogDNA is hiring for two Rust positions — a Senior Backend Software engineer and a Senior Security Engineer. Both positions are open to remote candidates in the U.S. Additionally, Dreamsolution is hiring a Rust/Python engineer in the Netherlands.
 

--- a/_transcripts/023-twir-348.md
+++ b/_transcripts/023-twir-348.md
@@ -1,9 +1,8 @@
 ---
-title: "This Week in Rust - Issue 348"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-07-21.mp3
+episode: _episodes/023-twir-348.md
 ---
 
-__Nell Shamrell-Harrington__: Greetings, everyone! Welcome to this week’s episode of This Week in Rust on the Rustacean Station. As always, I’m Nell Shamrell-Harrington, lead editor of This Week in Rust and also a Sr. Staff Research Engineer on the Rust team at Mozilla. 
+__Nell Shamrell-Harrington__: Greetings, everyone! Welcome to this week’s episode of This Week in Rust on the Rustacean Station. As always, I’m Nell Shamrell-Harrington, lead editor of This Week in Rust and also a Sr. Staff Research Engineer on the Rust team at Mozilla.
 
 This episode covers issue #348 of the This Week in Rust newsletter, published on July 20, 2020.
 
@@ -41,15 +40,15 @@ Now let’s focus on this week in RFCs.
 
 No RFCs were approved this week.
 
-One RFC was moved into final comment period. This RFC is titled “RFC: C unwind ABI.” We previously covered it on this podcast when it was opened. To recap: 
+One RFC was moved into final comment period. This RFC is titled “RFC: C unwind ABI.” We previously covered it on this podcast when it was opened. To recap:
 
 Unwinding is what happens when a program you are running throws an exception. When the exception is thrown, the runtime for the program will unwind the stack and essentially traverse backward through it, calling any clean up or error recovery code.
 
 Rust does not implement exceptions the way languages like C++ do, but it does support unwinding under two conditions. When rust code panics, it will unwind the stack. Also when Rust is interfacing with another programming language that does implement exceptions — such as C++ — it can also call functions in that language to unwind the stack.
 
-Currently, when foreign code — that means code not written in Rust — calls Rust code and the Rust code panics, the foreign code cannot unwind that Rust panic. Likewise, when Rust calls foreign code and that code throws an exception, Rust cannot unwind what happened in that code. 
+Currently, when foreign code — that means code not written in Rust — calls Rust code and the Rust code panics, the foreign code cannot unwind that Rust panic. Likewise, when Rust calls foreign code and that code throws an exception, Rust cannot unwind what happened in that code.
 
-This RFC seeks to change this by defining a new ABI string as an addition to the current ABI. An ABI is an application binary interface — it’s a way for two compiled binaries to interact with each other. The ABI string defined by this RFC makes it safe to unwind C++ frames with a Rust panic and unwind Rust frames with a C++ exception. 
+This RFC seeks to change this by defining a new ABI string as an addition to the current ABI. An ABI is an application binary interface — it’s a way for two compiled binaries to interact with each other. The ABI string defined by this RFC makes it safe to unwind C++ frames with a Rust panic and unwind Rust frames with a C++ exception.
 
 For more details and examples, make sure to read the full RFC.
 
@@ -69,7 +68,7 @@ Thank you so much to everyone who has taken the time to open RFCs - they are how
 
 There are several Rust job openings featured in this week’s newsletter. These include engineering positions at LogDNA, Electron, Noibu, OneSignal, OnePassword, Findora, ESR Labs, and a teaching position at the University of Paris. See the newsletter for links to the posting and all the details.
 
-As for Rust events, we have an upcoming online meetup in Berlin, Germany as well as the Rusty Days Virtual Rust Conference from July 27-August 8. I will be speaking at that one and introducing you to the internals of the Rust compiler and, in particular, the borrow checker. Additionally, in person Rust meetups are being held in Durham, North Carolina, Dallas, Texas, and Auckland, New Zealand. 
+As for Rust events, we have an upcoming online meetup in Berlin, Germany as well as the Rusty Days Virtual Rust Conference from July 27-August 8. I will be speaking at that one and introducing you to the internals of the Rust compiler and, in particular, the borrow checker. Additionally, in person Rust meetups are being held in Durham, North Carolina, Dallas, Texas, and Auckland, New Zealand.
 
 And that’s all for this podcast. Make sure to read the newsletter for even more great Rust content.
 

--- a/_transcripts/024-twir-349.md
+++ b/_transcripts/024-twir-349.md
@@ -1,9 +1,8 @@
 ---
-title: "This Week in Rust - Issue 349"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-07-28.mp3
+episode: _episodes/024-twir-349.md
 ---
 
-__Nell Shamrell-Harrington__: Hello everyone! I hope this podcast finds you doing as well as you can be in this very uncertain time across the world. This is the This Week in Rust update on the Rustacean station. As always, I’m Nell Shamrell-Harrington, lead editor of This Week in Rust and also a Sr. Staff Research Engineer on the Rust team at Mozilla. 
+__Nell Shamrell-Harrington__: Hello everyone! I hope this podcast finds you doing as well as you can be in this very uncertain time across the world. This is the This Week in Rust update on the Rustacean station. As always, I’m Nell Shamrell-Harrington, lead editor of This Week in Rust and also a Sr. Staff Research Engineer on the Rust team at Mozilla.
 
 This episode covers issue #349 of This Week in Rust, published on July 29, 2020.
 
@@ -47,7 +46,7 @@ The second RFC approved this week proposed adding a new function attribute calle
 
 There is one RFC is in final comment period this week — the ‘C unwind’ ABI. We’ve covered this RFC in detail on this podcast before, including last episode, so please give that a listen and take a look at the full RFC for more information.
 
-Three new RFCs were proposed this week. 
+Three new RFCs were proposed this week.
 
 The first of these, called “Add JSON backend to RustDoc”, describes a design for a JSON output for RustDoc. Currently, RustDoc’s output is HTML. RustDoc did have JSON output in the past, but it failed to keep up with the changing language and was taken out in 2016. RustDoc is now in a more stable position, so it is now possible to re-introduce this feature and ensure it’s stability. Read the RFC for all the details.
 
@@ -59,9 +58,8 @@ This week’s newsletter features several job postings for Rust engineers, inclu
 
 We also have several upcoming online and in person events in the Rust community. As for online events, you can go around the world and back on August 5 and 6 by attending online meetups in Johannesburg, South Africa, Dublin, Ireland, Buffalo, New York, Indianapolis, Indiana, Linz, Austria, and Berlin, Germany. There are also in person meetups taking place in Dallas, Texas and Auckland, New Zealand.
 
-And that concludes this week’s podcast, I hope the content in this week’s newsletter teaches you and inspires you. 
+And that concludes this week’s podcast, I hope the content in this week’s newsletter teaches you and inspires you.
 
 This Week in Rust is edited by myself, Andre Bogus, and Colton Donnelly. This week’s contributors included, using their GitHub usernames: Imor, Nnethercote, Matthewkmayer, Darksonn, Carlosgaldino, Alex-dukhno, Jamesmcm, Lights0123,ThibaudDauce, and Shinokada.
 
 As always, if you write a great article on Rust or happen to see one — please submit it to This Week in Rust by opening a pull request on our GitHub repo. Have a wonderful week everyone and please stay safe out there!
-

--- a/_transcripts/026-twir-350.md
+++ b/_transcripts/026-twir-350.md
@@ -1,6 +1,5 @@
 ---
-title: "This Week in Rust - Issue 350"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-08-03.mp3
+episode: _episodes/026-twir-350.md
 ---
 
 * placeholder to generate bulleted TOC

--- a/_transcripts/027-twir-351.md
+++ b/_transcripts/027-twir-351.md
@@ -1,6 +1,5 @@
 ---
-title: "This Week in Rust - Issue 351"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-08-11.mp3
+episode: _episodes/027-twir-351.md
 ---
 
 * placeholder to generate bulleted TOC
@@ -10,7 +9,7 @@ file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-08-11
 
 __Nell Shamrell-Harrington__: Hello Rustaceans and welcome to another episode of This Week in Rust here on the Rustacean Station.
 
-As always, I’m Nell Shamrell-Harrington, lead editor of This Week in Rust and also a Sr. Staff Research Engineer on the Rust team at Mozilla. 
+As always, I’m Nell Shamrell-Harrington, lead editor of This Week in Rust and also a Sr. Staff Research Engineer on the Rust team at Mozilla.
 
 This episode covers issue number 351 of This Week in Rust, published on August 11, 2020.
 
@@ -60,7 +59,7 @@ Moving on to events, lots of meetups are happening around the world including on
 
 Finally, make sure not to miss RustConf, taking place online, on August 20. And that’s a great transition into our interviews with the RustConf speakers.
 
-This week we hear from  Micah Tigley, Rebecca Turner, and Samuel Lim. 
+This week we hear from  Micah Tigley, Rebecca Turner, and Samuel Lim.
 
 Let’s start with Micah Tigley.
 

--- a/_transcripts/028-rust-1.44-1.45.md
+++ b/_transcripts/028-rust-1.44-1.45.md
@@ -1,7 +1,9 @@
 ---
-title: "What's New in Rust 1.44 and 1.45"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e027-rust-1.44-1.45.mp3
+episode: _episodes/028-rust-1.44-1.45.md
 ---
+
+{%- include util.html -%}
+[episode]: {{episode.url}}
 
 __Jon Gjengset__: Ben, we are back.
 
@@ -772,7 +774,7 @@ transcripts from their meetings. And this is a great way just to keep up with
 what things are important to the Rust core team at the moment. So I recommend
 you give that a look if you're interested. And I think that's all I have.
 
-__Ben__: And we'll link to that in the show notes. And, yeah, that's all that I
+__Ben__: And we'll link to that in the [show notes][episode]. And, yeah, that's all that I
 have, all that you have.
 
 __Jon__: Great. I guess I will see you again in one or two releases.

--- a/_transcripts/028-twir-352.md
+++ b/_transcripts/028-twir-352.md
@@ -1,7 +1,9 @@
 ---
-title: "This Week in Rust - Issue 352"
-file: https://audio.rustacean-station.org/file/rustacean-station/twir-2020-08-19.mp3
+episode: _episodes/028-twir-352.md
 ---
+
+{%- include util.html -%}
+[episode]: {{episode.url}}
 
 * placeholder to generate bulleted TOC
 {:toc}
@@ -36,7 +38,7 @@ If you are in the mood for a deep dive into Async programming, definitely check 
 
 Ryan Gorup - founder of Ebbflow - is back with another post about building Linux packages for Rust, in particular building them with GitHub Actions using Custom Actions and Docker Container Images. Check out the post for all of the information about building and hosting your build images, creating GitHub actions workflows, and more.
 
-Moving onto RFCs, it’s been a quiet week for Rust RFCs this week. No RFCs were approved, no RFCs are in final comment period, and no new RFCs were proposed. That means this week is a great opportunity to catch up with the RFCs currently in progress, make sure to check out the Rust RFC GitHub repo, linked in the show notes.
+Moving onto RFCs, it’s been a quiet week for Rust RFCs this week. No RFCs were approved, no RFCs are in final comment period, and no new RFCs were proposed. That means this week is a great opportunity to catch up with the RFCs currently in progress, make sure to check out the Rust RFC GitHub repo, linked in the [show notes][episode].
 
 As for upcoming events - the biggest one on my mind is RustConf, which comes to your screens this Thursday, August 20. I’m thrilled to be hosting it and I hope the interviews with the speakers you’ve heard over the past few weeks have helped you get excited about it as well. I can tell you firsthand how incredibly hard each of the speakers worked on their talks - they each did at least one run through with me, many did two, and a few even did three before finalizing their talk. I can’t wait for you to see their work!
 

--- a/_transcripts/029-redisjson.md
+++ b/_transcripts/029-redisjson.md
@@ -1,7 +1,9 @@
 ---
-title: "RedisJSON"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e029-redisjson.mp3
+episode: _episodes/029-redisjson.md
 ---
+
+{%- include util.html -%}
+[episode]: {{episode.url}}
 
 __Jeremy Webb__: Okay. Welcome to the Rustacean Station. My name is Jeremy, and
 I'm one of the editors and other hosts on the Rustacean Station here. Today, I'm
@@ -724,7 +726,7 @@ world, but we can be more realistic, as supposed to less idealistic when it
 comes to that, I think, given the state of things. Great, so I want to be
 respectful of your time, obviously, and we're probably running up against it
 here, but I will throw a link to your podcast, and your FOSDEM talk, and GitHub,
-as mentioned earlier, in our show notes and things like that. But before we wrap
+as mentioned earlier, in our [show notes][episode] and things like that. But before we wrap
 up specifically talking about Rust, I want to ask you two purely opinion
 questions which are: What's your Linux distro of choice? And what editor do you
 use when you're working in the best programming language in the universe, Rust?
@@ -797,7 +799,7 @@ yesterday, of season number one. So we have been around for the last four
 months, I think. But I think we have now a steady listenership of at least 5.5
 people, if not 6.
 
-__Jeremy__: Okay. I'll put a link to that in the show notes as well.
+__Jeremy__: Okay. I'll put a link to that in the [show notes][episode] as well.
 
 __Christoph__: Hopefully, this plug changes this in a better way. It's
 [linuxinlaws.eu](https://linuxinlaws.eu/).

--- a/_transcripts/030-krustlet.md
+++ b/_transcripts/030-krustlet.md
@@ -1,7 +1,9 @@
 ---
-title: "WebAssembly on the Server with Krustlet"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e030-krustlet.mp3
+episode: _episodes/030-krustlet.md
 ---
+
+{%- include util.html -%}
+[episode]: {{episode.url}}
 
 __Jeremy Jung__: Hey, this is Jeremy Jung. This episode I'm talking to Taylor
 Thomas about running WebAssembly on the server with Rust. He's an engineer on
@@ -410,7 +412,7 @@ that it could be done like that. Plus, you add on all the safety and security
 and correctness features inside of Rust, and it really helps us out.
 
 So we wrote several blog posts about that, that I can probably send around or
-link around if you send out show notes. But the main idea is that— it has
+link around if you send out [show notes][episode]. But the main idea is that— it has
 prevented us from shooting ourselves in the foot. Go has really easy concurrency
 things. Sometimes that's one of the things that I most miss about using Go for
 some of this, is if I want to do concurrency work, it's quite simple to set up.
@@ -942,14 +944,14 @@ amalgamation of all of this, but you could look at the
 check that.
 
 __Jeremy__: And we can probably get the Krustlet-specific posts and then put
-those in the show notes as well.
+those in the [show notes][episode] as well.
 
 __Taylor__: Yeah, I can send those. But it's
 [`deislabs.io/posts`](https://deislabs.io/posts/). That's posts for all of our
 projects, but you'll see some, at least three blog posts there about Krustlet.
 One was around our stack and heap allocation problems that we had, and some
 lessons learned there. So those were some other places you can go. We have some
-other posts that hopefully we can send in the show notes that kind of give an
+other posts that hopefully we can send in the [show notes][episode] that kind of give an
 overview of the different things, like the reasoning behind this. If you're more
 interested, that's from a high level, like a business perspective. We have a
 post for that. We have some other things about the security things we got from

--- a/_transcripts/031-rust-1.46-1.47.md
+++ b/_transcripts/031-rust-1.46-1.47.md
@@ -1,7 +1,9 @@
 ---
-title: "What's New in Rust 1.46 and 1.47"
-file: https://audio.rustacean-station.org/file/rustacean-station/rustacean-station-e031-rust-1.46-1.47.mp3
+episode: _episodes/031-rust-1.46-1.47.md
 ---
+
+{%- include util.html -%}
+[episode]: {{episode.url}}
 
 __Jon Gjengset__: Hello, fellow humans. We are back yet again. Aren't we, Ben?
 
@@ -709,7 +711,7 @@ __Ben__: Right.
 __Jon__: That's really what we should be saying, Rather than saying that tau is
 2π.
 
-__Ben__: We'll link The Tau Manifesto in the release notes. It's worth a read.
+__Ben__: We'll link The Tau Manifesto in the [release notes][episode]. It's worth a read.
 It's good. It's just good fun math knowledge to have, in terms of like,
 illuminating why certain things are the way they are. It kind of just shows,
 too, like there's path dependence in a lot of fields. Or maybe if people had
@@ -749,7 +751,7 @@ was very happy to see, which is basically a SemVer compatibility guide. So this
 is a document that essentially goes through what are all of the things that
 constitute breaking changes in Rust, and what things do not constitute breaking
 changes. And also gives some examples of which are which, and why these matter.
-So I highly recommend you give this a read. We'll link that in the show notes as
+So I highly recommend you give this a read. We'll link that in the [show notes][episode] as
 well. And also, and this is very minor, but it's going to matter on, like,
 you're going to notice this on the usability level, which is that `cargo help`—
 so if you type `cargo help`, followed by some command on the command line, it
@@ -818,7 +820,7 @@ data parallel CPU operations, to work better in a portable way in Rust. And I
 think both of these groups are happy to get input and advice into their
 discussions. I think all their discussions are public. If you want to get
 involved and care about either of these use cases, then I highly recommend you
-do so. And we'll link to those in the show notes as well.
+do so. And we'll link to those in the [show notes][episode] as well.
 
 __Ben__: Speaking of community, I know that— I think we mentioned last time, but
 also it's worth reiterating, is that Jon has been expanding the role of our

--- a/transcript_style_guide.md
+++ b/transcript_style_guide.md
@@ -65,9 +65,22 @@ right verb tense), by all means use the correct one by default.
 ## Hyperlinks
 
 Links should generally be avoided, and instead inserted into the show notes if
-they are missing from there. The exception might be if it is not at all clear
-from the sentence what is going on (such as if the name of a feature is given
-incorrectly).
+they are missing from there.  One exception is if someone says, "we'll leave a
+link to that in the show notes," link to the show notes as follows:
+
+1. Ensure that at the top of the page, the following exists (it will compute
+   the right link URL from the front matter):
+
+       {%- include util.html -%}
+       [episode]: {{episode.url}}
+
+2. Add the hyperlink like this:
+
+        We'll link that in the [show notes][episode] so you can find it.
+
+Another exception to the avoid-links guideline might be if it is not at all
+clear from the sentence what is going on (such as if the name of a feature is
+given incorrectly).
 
 ## When to use `code` tags
 


### PR DESCRIPTION
This is my first pass at #86, for review purposes.  I have only added links to one episode, just to show what it looks like.

I'm not entirely satisfied with this method of linking from the transcript page to the episode page, because it's duplicating the effort done in `_layouts/transcript.html`.  I haven't found an easy way to resolve this, though:
- Variables set in the layout don't get propagated to the page environment.
- Variables set in the front matter don't seem compatible with the liquid `link` function (which is nice because it verifies the link target exists, and will automatically substitute the right permalink URL).
- If we want to compute the episode url in liquid, and use it in both the layout and the transcript.md, I think this would require putting that liquid code in a separate file, and then `include`-ing that file from both. This seems like a lot of work to avoid pasting the episode filename.
