### PR TITLE
Fix RSS ordering & linking

### DIFF
--- a/pages/podcast.rss
+++ b/pages/podcast.rss
@@ -40,9 +40,10 @@ permalink: "/podcast.rss"
 			<itunes:email>jon@thesquareplanet.com</itunes:email>
 		</itunes:owner>
 
-		{% for post in site.episodes %}
+		{% assign episodes = site.episodes | reverse %}
+		{% for post in episodes %}
 		<item>
-			<!-- <link>{{ post.url | absolute_url }}</link> -->
+			<link>{{ post.url | absolute_url }}</link>
 			<pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
 			{% if post.guid %}
 			<guid isPermaLink="false">{{ post.guid }}</guid>


### PR DESCRIPTION
👋 Fixing up the RSS feed. Currently, posts are listed oldest first, rather than new episodes at the top. Additionally, the posts are unlinked so can't be clicked through to.

**Current state:**
![image](https://user-images.githubusercontent.com/40188355/138859302-917ae4e9-fbd1-4457-89ec-abac04d95395.png)

**Amended:**
![image](https://user-images.githubusercontent.com/40188355/138859177-d41ac47a-ecaa-4a4e-9eac-7307c41c00b4.png)
