### PR TITLE
Open show notes/references links in new tab

### DIFF
--- a/_episodes/000-rust-1.36.0.md
+++ b/_episodes/000-rust-1.36.0.md
@@ -14,25 +14,25 @@ Meet Rustacean Station, a new Rust "meta podcast", and take a dive into the new 
 
 If you would like to offer Rust-related podcast content for us to host, or would like advice and resources on making your own Rust podcast, get in touch with us via the venues below!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### In the episode
 
- - [@4:27] - [`std::future`](https://doc.rust-lang.org/std/future/trait.Future.html)
- - [@11:29] - [`std::task`](https://doc.rust-lang.org/std/task/struct.Waker.html)
- - [@14:22] - the [alloc](https://doc.rust-lang.org/alloc/index.html) crate
- - [@18:52] - `std::collections::HashMap` and [hashbrown](https://github.com/rust-lang/hashbrown)
- - [@22:50] - [`std::mem::MaybeUninit`](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html) and [the deprecation](https://gankro.github.io/blah/initialize-me-maybe/) of [`std::mem::uninitialized`](https://gankro.github.io/blah/initialize-me-maybe/)  (mentioned: [`Error::type_id`](https://github.com/rust-lang/rust/issues/60784) destabilization and [`std::pin`](https://github.com/rust-lang/rust/issues/49150) discussion)
- - [@36:24] - [NLL for Rust 2015](http://blog.pnkfx.org/blog/2019/06/26/breaking-news-non-lexical-lifetimes-arrives-for-everyone/) (mentioned: [MIR](https://blog.rust-lang.org/2016/04/19/MIR.html))
- - [@44:45] - [`cargo --offline`](https://github.com/rust-lang/cargo/issues/4686) and [`cargo fetch`](https://doc.rust-lang.org/cargo/commands/cargo-fetch.html)
+ - [@4:27] - [`std::future`](https://doc.rust-lang.org/std/future/trait.Future.html){:target="_blank"}
+ - [@11:29] - [`std::task`](https://doc.rust-lang.org/std/task/struct.Waker.html){:target="_blank"}
+ - [@14:22] - the [alloc](https://doc.rust-lang.org/alloc/index.html) crate{:target="_blank"}
+ - [@18:52] - `std::collections::HashMap` and [hashbrown](https://github.com/rust-lang/hashbrown){:target="_blank"}
+ - [@22:50] - [`std::mem::MaybeUninit`](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html) and [the deprecation](https://gankro.github.io/blah/initialize-me-maybe/) of [`std::mem::uninitialized`](https://gankro.github.io/blah/initialize-me-maybe/)  (mentioned: [`Error::type_id`](https://github.com/rust-lang/rust/issues/60784) destabilization and [`std::pin`](https://github.com/rust-lang/rust/issues/49150) discussion){:target="_blank"}
+ - [@36:24] - [NLL for Rust 2015](http://blog.pnkfx.org/blog/2019/06/26/breaking-news-non-lexical-lifetimes-arrives-for-everyone/) (mentioned: [MIR](https://blog.rust-lang.org/2016/04/19/MIR.html)){:target="_blank"}
+ - [@44:45] - [`cargo --offline`](https://github.com/rust-lang/cargo/issues/4686) and [`cargo fetch`](https://doc.rust-lang.org/cargo/commands/cargo-fetch.html){:target="_blank"}
  - [@46:50] - ongoing stdlib constification
- - [@47:25] - [`read_vectored`](https://doc.rust-lang.org/std/io/trait.Read.html#method.read_vectored) and [`write_vectored`](https://doc.rust-lang.org/std/io/trait.Write.html#method.write_vectored)
- - [@49:05] - [`Iterator::copied`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.copied)
- - [@49:58] - [`dbg!`](https://doc.rust-lang.org/std/macro.dbg.html) enhancements
- - [@51:19] - [`#[must_use]`](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute) for [`is_err`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_err) and [`is_ok`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_ok)
+ - [@47:25] - [`read_vectored`](https://doc.rust-lang.org/std/io/trait.Read.html#method.read_vectored) and [`write_vectored`](https://doc.rust-lang.org/std/io/trait.Write.html#method.write_vectored){:target="_blank"}
+ - [@49:05] - [`Iterator::copied`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.copied){:target="_blank"}
+ - [@49:58] - [`dbg!`](https://doc.rust-lang.org/std/macro.dbg.html) enhancements{:target="_blank"}
+ - [@51:19] - [`#[must_use]`](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute){:target="_blank"} for [`is_err`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_err){:target="_blank"} and [`is_ok`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_ok){:target="_blank"}
 
 ### Credits
 

--- a/_episodes/001-ruma.md
+++ b/_episodes/001-ruma.md
@@ -10,31 +10,31 @@ reddit: https://www.reddit.com/r/rust/comments/cp1iai/ruma_and_the_matrix_commun
 guid: "rustacean-station//episode/001-ruma"
 ---
 
-We interview Jimmy Cuadra about [Matrix](https://matrix.org/), an open and decentralized communication protocol, and his implementation in Rust known as [Ruma](https://github.com/ruma/ruma).
+We interview Jimmy Cuadra about [Matrix](https://matrix.org/){:target="_blank"}, an open and decentralized communication protocol, and his implementation in Rust known as [Ruma](https://github.com/ruma/ruma){:target="_blank"}.
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
 * [@01:35] - Meet Jimmy Cuadra
 * [@04:46] - How did you get into Rust?
-  * [@bascule (Tony Arcieri)](https://twitter.com/bascule)
-  * [The Rust Programming Language Book](https://doc.rust-lang.org/book/)
+  * [@bascule (Tony Arcieri)](https://twitter.com/bascule){:target="_blank"}
+  * [The Rust Programming Language Book](https://doc.rust-lang.org/book/){:target="_blank"}
 * [@08:47] - What is Matrix?
-  * [Matrix: an open network for secure, decentralized communication](https://matrix.org/)
-  * [libpurple](https://developer.pidgin.im/wiki/WhatIsLibpurple)
-  * [Ruma: Introduction to Matrix](https://www.ruma.io/docs/matrix/)
+  * [Matrix: an open network for secure, decentralized communication](https://matrix.org/){:target="_blank"}
+  * [libpurple](https://developer.pidgin.im/wiki/WhatIsLibpurple){:target="_blank"}
+  * [Ruma: Introduction to Matrix](https://www.ruma.io/docs/matrix/){:target="_blank"}
 * [@14:32] - Why "Matrix"?
 * [@16:44] - What forms of communication does Matrix enable?
 * [@17:59] - What pieces of Matrix does Ruma implement?
 * [@20:27] - Why did you decide to use Rust?
 * [@23:52] - How challenging has Ruma been to implement?
 * [@30:27] - What libraries does Ruma leverage?
-  * [Serde: a framework for serializing and deserializing data structures efficiently and generically](https://crates.io/crates/serde)
-  * [Diesel: a safe, extensible ORM and query builder](https://crates.io/crates/diesel)
+  * [Serde: a framework for serializing and deserializing data structures efficiently and generically](https://crates.io/crates/serde){:target="_blank"}
+  * [Diesel: a safe, extensible ORM and query builder](https://crates.io/crates/diesel){:target="_blank"}
 * [@34:02] - If you could start all over again, what would you do differently?
 * [@38:57] - Does Ruma use any unstable Rust features? Has it previously?
 * [@42:30] - What other implementations of Matrix exist?

--- a/_episodes/002-colorado-gold-rust.md
+++ b/_episodes/002-colorado-gold-rust.md
@@ -10,36 +10,36 @@ reddit: https://www.reddit.com/r/rust/comments/cvbe9x/organizing_colorado_gold_r
 guid: "rustacean-station//episode/002-colorado-gold-rust/"
 ---
 
-We interview J Haigh about their experience organizing this year's first-ever [Colorado Gold Rust](https://www.cogoldrust.com/) conference, what brought them to Rust, and what inspired them to give back to Rust's community. 
+We interview J Haigh about their experience organizing this year's first-ever [Colorado Gold Rust](https://www.cogoldrust.com/){:target="_blank"} conference, what brought them to Rust, and what inspired them to give back to Rust's community.
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
-* [@00:41] - [Colorado Gold Rust](https://www.cogoldrust.com/)
+* [@00:41] - [Colorado Gold Rust](https://www.cogoldrust.com/){:target="_blank"}
 * [@01:48] - What got you into Rust?
-  * [RustConf](https://rustconf.com/)
-  * [@ag_dubs (Ashley Williams)](https://twitter.com/ag_dubs)
-  * [@carols10cents (Carol Nichols)](https://twitter.com/carols10cents)
+  * [RustConf](https://rustconf.com/){:target="_blank"}
+  * [@ag_dubs (Ashley Williams)](https://twitter.com/ag_dubs){:target="_blank"}
+  * [@carols10cents (Carol Nichols)](https://twitter.com/carols10cents){:target="_blank"}
 * [@03:01] - Getting involved with the Rust community
-  * [Rust Boulder/Denver Meetup](https://www.meetup.com/Rust-Boulder-Denver/)
-  * [@focusaurus (Peter Lyons)](https://twitter.com/focusaurus)
-* [@07:50] - What is the [Recurse Center](https://www.recurse.com/)?
+  * [Rust Boulder/Denver Meetup](https://www.meetup.com/Rust-Boulder-Denver/){:target="_blank"}
+  * [@focusaurus (Peter Lyons)](https://twitter.com/focusaurus){:target="_blank"}
+* [@07:50] - What is the [Recurse Center](https://www.recurse.com/){:target="_blank"}?
 * [@09:21] - Organizing a conference
-  * [Auraria Campus](https://www.ahec.edu/)
-  * [@argorak (Florian Gilcher)](https://twitter.com/Argorak)
-  * [Rust Fest](https://www.rustfest.eu)
-  * [Rust Community Events Team's example timeline for organizing a conference](https://github.com/rust-community/events-team/blob/master/guidelines/timeline.md)
-  * [Rust Belt Rust](https://www.rust-belt-rust.com/) 
-  * [Rust Belt Rust 2018's budgeting report](https://www.integer32.com/2018/11/29/2018-rust-belt-rust-finance-report.html)
+  * [Auraria Campus](https://www.ahec.edu/){:target="_blank"}
+  * [@argorak (Florian Gilcher)](https://twitter.com/Argorak){:target="_blank"}
+  * [Rust Fest](https://www.rustfest.eu){:target="_blank"}
+  * [Rust Community Events Team's example timeline for organizing a conference](https://github.com/rust-community/events-team/blob/master/guidelines/timeline.md){:target="_blank"}
+  * [Rust Belt Rust](https://www.rust-belt-rust.com/){:target="_blank"} 
+  * [Rust Belt Rust 2018's budgeting report](https://www.integer32.com/2018/11/29/2018-rust-belt-rust-finance-report.html){:target="_blank"}
 * [@17:27] - What have you learned for next time?
 * [@19:36] - Who is helping with the conference?
-  * [Nicholas Young](https://www.secretfader.com/)
+  * [Nicholas Young](https://www.secretfader.com/){:target="_blank"}
 * [@22:05] - Community Inclusivity
-* [@24:44] - [CFP software](https://github.com/rubycentral/cfp-app)
+* [@24:44] - [CFP software](https://github.com/rubycentral/cfp-app){:target="_blank"}
 * [@25:34] - Finding a venue for a conference
 
 ### Credits

--- a/_episodes/003-rust-1.37.0.md
+++ b/_episodes/003-rust-1.37.0.md
@@ -10,14 +10,14 @@ reddit: https://www.reddit.com/r/rust/comments/cxz031/rustacean_station_podcast_
 guid: "rustacean-station//episode/003-rust-1.37.0/"
 ---
 
-We review the new features in [the Rust 1.37 release](https://blog.rust-lang.org/2019/08/15/Rust-1.37.0.html) and give shout-outs to all the volunteers who have helped make Rustacean Station so far.
+We review the new features in [the Rust 1.37 release](https://blog.rust-lang.org/2019/08/15/Rust-1.37.0.html){:target="_blank"} and give shout-outs to all the volunteers who have helped make Rustacean Station so far.
 
 Get in touch with us if you'd like to be interviewed, propose a topic, or help out!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
@@ -29,7 +29,7 @@ Get in touch with us if you'd like to be interviewed, propose a topic, or help o
 * [@10:17] - `#[repr(align(N))]` on enums
 * [@11:06] - Library changes
 * [@16:48] - New sponsors of Rust infrastructure
-  * [Async/Await in Libra Core](https://community.libra.org/t/async-await-in-libra-core/1566)
+  * [Async/Await in Libra Core](https://community.libra.org/t/async-await-in-libra-core/1566){:target="_blank"}
 * [@19:58] - `async`/`await` stabilization in Rust 1.39
 * [@22:08] - Miscellaneous new features
 * [@26:06] - Thanking the people who make Rustacean Station possible!

--- a/_episodes/004-rust-in-production-armin-ronacher.md
+++ b/_episodes/004-rust-in-production-armin-ronacher.md
@@ -10,14 +10,14 @@ reddit: https://www.reddit.com/r/rust/comments/d5ydeg/rust_in_production_an_inte
 guid: "rustacean-station//episode/004-rust-in-production-armin-ronacher/"
 ---
 
-[Armin Ronacher](https://twitter.com/mitsuhiko) talks about getting into Rust, when to use it, writing Rust extensions for Python, building the [Symbolicator](https://github.com/getsentry/symbolicator) web application with actix, creating debugging libraries, and the Rust ecosystem.
+[Armin Ronacher](https://twitter.com/mitsuhiko){:target="_blank"} talks about getting into Rust, when to use it, writing Rust extensions for Python, building the [Symbolicator](https://github.com/getsentry/symbolicator){:target="_blank"} web application with actix, creating debugging libraries, and the Rust ecosystem.
 
 Get in touch with us if you'd like to be interviewed, propose a topic, or help out!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
@@ -26,7 +26,7 @@ Get in touch with us if you'd like to be interviewed, propose a topic, or help o
 * [@04:50] - Rust doesn't need asynchronous code
 * [@06:10] - Building thread safe applications
 * [@07:05] - What excited you about using Rust?
-* [@08:59] - [Sentry](https://sentry.io/welcome/)
+* [@08:59] - [Sentry](https://sentry.io/welcome/){:target="_blank"}
 * [@11:41] - Introducing Rust to Sentry
 * [@13:49] - Anything easier to write in Rust vs Python?
 * [@16:53] - Writing extensions vs writing services

--- a/_episodes/005-rust-1.38.0.md
+++ b/_episodes/005-rust-1.38.0.md
@@ -10,43 +10,43 @@ reddit: https://www.reddit.com/r/rust/comments/dhw0ek/whats_new_in_rust_138_rust
 guid: "rustacean-station//episode/005-rust-1.38.0/"
 ---
 
-Jon and Ben review the changes introduced by [the Rust 1.38 release](https://blog.rust-lang.org/2019/09/26/Rust-1.38.0.html).
+Jon and Ben review the changes introduced by [the Rust 1.38 release](https://blog.rust-lang.org/2019/09/26/Rust-1.38.0.html){:target="_blank"}.
 
 Get in touch with us if you'd like to be interviewed, propose a topic for an episode, or help out!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
 * [@1:15] - Pipelined compilation
 * [@3:25] - Linting some incorrect uses of `mem::uninitialized`
-    * [Rustacean Station episode on Rust 1.36 with discussion on `std::mem::MaybeUninit`](https://rustacean-station.org/episode/000-rust-1.36.0/)
+    * [Rustacean Station episode on Rust 1.36 with discussion on `std::mem::MaybeUninit`](https://rustacean-station.org/episode/000-rust-1.36.0/){:target="_blank"}
 * [@6:30] - `#[deprecated]` attribute on macros
-    * [Rust reference: Diagnostic attributes](https://doc.rust-lang.org/stable/reference/attributes/diagnostics.html)
+    * [Rust reference: Diagnostic attributes](https://doc.rust-lang.org/stable/reference/attributes/diagnostics.html){:target="_blank"}
 * [@11:30] - `std::any::type_name`
-    * [Security advisory for the destabilization of `std::error::Error::type_id` in Rust 1.34.2](https://groups.google.com/d/msg/rustlang-security-announcements/aZabeCMUv70/-2Y6-SL6AQAJ)
+    * [Security advisory for the destabilization of `std::error::Error::type_id` in Rust 1.34.2](https://groups.google.com/d/msg/rustlang-security-announcements/aZabeCMUv70/-2Y6-SL6AQAJ){:target="_blank"}
 * [@16:00] - `slice::{concat, connect, join}` now accepts `&[T]` in addition to `&T`
 * [@18:10] - `*const T` and `*mut T` now implement `std::marker::Unpin`
 * [@20:55] - New convenience methods for working with `std::time::Duration`
 * [@22:25] - `cargo fix --clippy`
 * [@23:40] - Diff-friendly format for Cargo.lock
 * [@25:00] - Looking forward to Rust 1.39
-    * [futures v0.3 milestone](https://github.com/rust-lang-nursery/futures-rs/milestone/2)
-    * [tokio v0.2 milestone](https://github.com/tokio-rs/tokio/milestone/2)
-    * [tower v0.1 milestone](https://github.com/tower-rs/tower/milestone/1)
-    * [hyper v0.13 milestone](https://github.com/hyperium/hyper/milestone/5)
+    * [futures v0.3 milestone](https://github.com/rust-lang-nursery/futures-rs/milestone/2){:target="_blank"}
+    * [tokio v0.2 milestone](https://github.com/tokio-rs/tokio/milestone/2){:target="_blank"}
+    * [tower v0.1 milestone](https://github.com/tower-rs/tower/milestone/1){:target="_blank"}
+    * [hyper v0.13 milestone](https://github.com/hyperium/hyper/milestone/5){:target="_blank"}
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Zoran Zaric](https://twitter.com/zoranzaric)
+Audio Editing: [Zoran Zaric](https://twitter.com/zoranzaric){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie/)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie/){:target="_blank"}
 
 Hosts: Jon Gjengset and Ben Striegel

--- a/_episodes/006-rust-1.39.0.md
+++ b/_episodes/006-rust-1.39.0.md
@@ -10,7 +10,7 @@ reddit: https://www.reddit.com/r/rust/comments/e20uqy/rustacean_station_podcast_
 guid: "rustacean-station//episode/006-rust-1.29.0/"
 ---
 
-Jon and Ben review the long-awaited changes in [Rust 1.39](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html).
+Jon and Ben review the long-awaited changes in [Rust 1.39](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html){:target="_blank"}.
 
 ### Contributing to Rustacean Station
 
@@ -18,41 +18,41 @@ Jon and Ben review the long-awaited changes in [Rust 1.39](https://blog.rust-lan
 
 Rustacean Station is a community project; get in touch with us if you'd like to be interviewed, propose a topic for an episode, or help create the podcast itself!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
-- [@1:03] - [References to by-move bindings in match guards](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html#references-to-by-move-bindings-in-match-guards)
-- [@2:44] - [Attributes on function parameters](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html#attributes-on-function-parameters)
-- [@7:01] - [Borrow check migration warnings are hard errors in Rust 2018](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html#borrow-check-migration-warnings-are-hard-errors-in-rust-2018)
-    - ["NLL for Rust 2015" in Rustacean Station episode on Rust 1.36 (timestamp: 36:24)](https://rustacean-station.org/episode/000-rust-1.36.0/)
-- [@10:15] - [More const fns in the standard library](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html#more-const-fns-in-the-standard-library)
-    - [Inside Rust Blog: `if` and `match` in constants on nightly Rust](https://blog.rust-lang.org/inside-rust/2019/11/25/const-if-match.html)
-- [@14:16] - [Improvements to `std::time::Instant`](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html#additions-to-the-standard-library)
-- [@16:22] - [rustup 1.20.0](https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html)
-- [@19:32] - [Stable async/await](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html#the-await-is-over,-async-fns-are-here)
-    - ["`std::future`" in Rustacean Station episode on Rust 1.36 (timestamp: 4:27)](https://rustacean-station.org/episode/000-rust-1.36.0/)
-    - [How Rust optimizes async/await I](https://tmandry.gitlab.io/blog/posts/optimizing-await-1/)
-    - [How Rust optimizes async/await II](https://tmandry.gitlab.io/blog/posts/optimizing-await-2/)
-    - [Rust Blog: Async-await on stable Rust!](https://blog.rust-lang.org/2019/11/07/Async-await-stable.html)
-    - [Announcing the Async Interviews](https://smallcultfollowing.com/babysteps/blog/2019/11/22/announcing-the-async-interviews/)
-    - [`wasm-bindgen-futures`](https://crates.io/crates/wasm-bindgen-futures)
+- [@1:03] - [References to by-move bindings in match guards](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html#references-to-by-move-bindings-in-match-guards){:target="_blank"}
+- [@2:44] - [Attributes on function parameters](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html#attributes-on-function-parameters){:target="_blank"}
+- [@7:01] - [Borrow check migration warnings are hard errors in Rust 2018](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html#borrow-check-migration-warnings-are-hard-errors-in-rust-2018){:target="_blank"}
+    - ["NLL for Rust 2015" in Rustacean Station episode on Rust 1.36 (timestamp: 36:24)](https://rustacean-station.org/episode/000-rust-1.36.0/){:target="_blank"}
+- [@10:15] - [More const fns in the standard library](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html#more-const-fns-in-the-standard-library){:target="_blank"}
+    - [Inside Rust Blog: `if` and `match` in constants on nightly Rust](https://blog.rust-lang.org/inside-rust/2019/11/25/const-if-match.html){:target="_blank"}
+- [@14:16] - [Improvements to `std::time::Instant`](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html#additions-to-the-standard-library){:target="_blank"}
+- [@16:22] - [rustup 1.20.0](https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html){:target="_blank"}
+- [@19:32] - [Stable async/await](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html#the-await-is-over,-async-fns-are-here){:target="_blank"}
+    - ["`std::future`" in Rustacean Station episode on Rust 1.36 (timestamp: 4:27)](https://rustacean-station.org/episode/000-rust-1.36.0/){:target="_blank"}
+    - [How Rust optimizes async/await I](https://tmandry.gitlab.io/blog/posts/optimizing-await-1/){:target="_blank"}
+    - [How Rust optimizes async/await II](https://tmandry.gitlab.io/blog/posts/optimizing-await-2/){:target="_blank"}
+    - [Rust Blog: Async-await on stable Rust!](https://blog.rust-lang.org/2019/11/07/Async-await-stable.html){:target="_blank"}
+    - [Announcing the Async Interviews](https://smallcultfollowing.com/babysteps/blog/2019/11/22/announcing-the-async-interviews/){:target="_blank"}
+    - [`wasm-bindgen-futures`](https://crates.io/crates/wasm-bindgen-futures){:target="_blank"}
 - [@34:42] - What's next in Rust?
-    - [Polonius](https://github.com/rust-lang/polonius)
-    - [Chalk](https://github.com/rust-lang/chalk)
-- [@36:20] - [A public call for feedback for the Rust 2020 Development Roadmap](https://blog.rust-lang.org/2019/10/29/A-call-for-blogs-2020.html)
+    - [Polonius](https://github.com/rust-lang/polonius){:target="_blank"}
+    - [Chalk](https://github.com/rust-lang/chalk){:target="_blank"}
+- [@36:20] - [A public call for feedback for the Rust 2020 Development Roadmap](https://blog.rust-lang.org/2019/10/29/A-call-for-blogs-2020.html){:target="_blank"}
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Jeremy Jung](https://www.softwaresessions.com)
+Audio Editing: [Jeremy Jung](https://www.softwaresessions.com){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie/)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie/){:target="_blank"}
 
 Hosts: Jon Gjengset and Ben Striegel

--- a/_episodes/007-zola.md
+++ b/_episodes/007-zola.md
@@ -7,7 +7,7 @@ length: "52224834"
 reddit: https://www.reddit.com/r/rust/comments/ed3qyd/an_interview_with_the_creator_of_zola_formerly/
 ---
 
-[Vincent Prouillet](https://www.vincentprouillet.com/) talks about his experience building the [Zola](https://twitter.com/jertype) static site generator (formerly known as Gutenberg) and reflects on five years of working with Rust.
+[Vincent Prouillet](https://www.vincentprouillet.com/){:target="_blank"} talks about his experience building the [Zola](https://twitter.com/jertype){:target="_blank"} static site generator (formerly known as Gutenberg) and reflects on five years of working with Rust.
 
 ### Contributing to Rustacean Station
 
@@ -15,10 +15,10 @@ reddit: https://www.reddit.com/r/rust/comments/ed3qyd/an_interview_with_the_crea
 
 Rustacean Station is a community project; get in touch with us if you'd like to be interviewed, propose a topic for an episode, or help create the podcast itself!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps
 
@@ -49,56 +49,56 @@ In this section, leave timestamped notes of the form:
 ### References and Resources
 
 #### Vincent Prouillet
-- [Personal Site](https://www.vincentprouillet.com/)
-- [@20100Prouillet](https://twitter.com/20100Prouillet)
+- [Personal Site](https://www.vincentprouillet.com/){:target="_blank"}
+- [@20100Prouillet](https://twitter.com/20100Prouillet){:target="_blank"}
 
 #### Zola
-- [Zola Website](https://www.getzola.org)
-- [Zola Forum](https://zola.discourse.group/)
+- [Zola Website](https://www.getzola.org){:target="_blank"}
+- [Zola Forum](https://zola.discourse.group/){:target="_blank"}
 
 #### Tools/Crates used by Zola
-- [pulldown-cmark](https://github.com/raphlinus/pulldown-cmark) (Markdown)
-- [syntec](https://github.com/trishume/syntect) (Syntax highlighting using Sublime Text definitions)
-- [rayon](https://github.com/rayon-rs/rayon) (Parallel computation)
-- [heaptrack](https://github.com/KDE/heaptrack) (Memory Profiler)
+- [pulldown-cmark](https://github.com/raphlinus/pulldown-cmark){:target="_blank"} (Markdown)
+- [syntec](https://github.com/trishume/syntect){:target="_blank"} (Syntax highlighting using Sublime Text definitions)
+- [rayon](https://github.com/rayon-rs/rayon){:target="_blank"} (Parallel computation)
+- [heaptrack](https://github.com/KDE/heaptrack){:target="_blank"} (Memory Profiler)
 
 #### Static Site Hosts
-- [Github Pages](https://pages.github.com/)
-- [Netlify](https://www.netlify.com/)
+- [Github Pages](https://pages.github.com/){:target="_blank"}
+- [Netlify](https://www.netlify.com/){:target="_blank"}
 
 #### Crates for Web Applications
-- [jsonwebtoken](https://github.com/Keats/jsonwebtoken)
-- [Bcrypt](https://github.com/Keats/rust-bcrypt)
-- [Validator](https://github.com/Keats/validator)
+- [jsonwebtoken](https://github.com/Keats/jsonwebtoken){:target="_blank"}
+- [Bcrypt](https://github.com/Keats/rust-bcrypt){:target="_blank"}
+- [Validator](https://github.com/Keats/validator){:target="_blank"}
 
 #### Compiled Template Engines
-- [askama](https://github.com/djc/askama)
-- [maud](https://maud.lambda.xyz/)
-- [horrowshow](https://github.com/Stebalien/horrorshow-rs)
+- [askama](https://github.com/djc/askama){:target="_blank"}
+- [maud](https://maud.lambda.xyz/){:target="_blank"}
+- [horrowshow](https://github.com/Stebalien/horrorshow-rs){:target="_blank"}
 
 #### Runtime Template Engines
-- [Tera](https://github.com/Keats/tera) ([Jinja2](https://www.palletsprojects.com/p/jinja/)-like HTML template engine)
-- [ramhorns](https://github.com/maciejhirsz/ramhorns)
-- [rust-mustache](https://github.com/nickel-org/rust-mustache)
+- [Tera](https://github.com/Keats/tera){:target="_blank"} ([Jinja2](https://www.palletsprojects.com/p/jinja/){:target="_blank"}-like HTML template engine)
+- [ramhorns](https://github.com/maciejhirsz/ramhorns){:target="_blank"}
+- [rust-mustache](https://github.com/nickel-org/rust-mustache){:target="_blank"}
 
 #### Static Site Generators
-- [Hugo](https://www.gohugo.io)
-- [Jekyll](https://www.jekyllrb.com)
-- [Pelican](https://blog.getpelican.com/)
+- [Hugo](https://www.gohugo.io){:target="_blank"}
+- [Jekyll](https://www.jekyllrb.com){:target="_blank"}
+- [Pelican](https://blog.getpelican.com/){:target="_blank"}
 
 #### Other links
-- [Forestry](https://forestry.io/) (WYSIWYG CMS for Static Sites)
-- [Keyword Arguments RFC](https://github.com/rust-lang/rfcs/issues/323)
-- [kickstart](https://github.com/Keats/kickstart) (Scaffolding tool)
+- [Forestry](https://forestry.io/){:target="_blank"} (WYSIWYG CMS for Static Sites)
+- [Keyword Arguments RFC](https://github.com/rust-lang/rfcs/issues/323){:target="_blank"}
+- [kickstart](https://github.com/Keats/kickstart){:target="_blank"} (Scaffolding tool)
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Jeremy Jung](https://twitter.com/jertype)
+Audio Editing: [Jeremy Jung](https://twitter.com/jertype){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie){:target="_blank"}
 
-Hosts: [Jeremy Jung](https://twitter.com/jertype)
+Hosts: [Jeremy Jung](https://twitter.com/jertype){:target="_blank"}

--- a/_episodes/008-oli-miri.md
+++ b/_episodes/008-oli-miri.md
@@ -7,7 +7,7 @@ length: "23497525"
 reddit: https://www.reddit.com/r/rust/comments/eep97x/compiletime_evaluation_interpreted_rust_and_ub/
 ---
 
-In the first of our mini-interviews from RustFest 2019, we talk to [Oliver Scherer](https://twitter.com/oli_obk) about [Miri](https://github.com/rust-lang/miri), an interpreter for rustc's internal bytecode, its use in `const`-evaluation, and its potential as an external tool for sanitizing `unsafe` code.
+In the first of our mini-interviews from RustFest 2019, we talk to [Oliver Scherer](https://twitter.com/oli_obk){:target="_blank"} about [Miri](https://github.com/rust-lang/miri){:target="_blank"}, an interpreter for rustc's internal bytecode, its use in `const`-evaluation, and its potential as an external tool for sanitizing `unsafe` code.
 
 <!--
 The episode introduction goes here.
@@ -22,10 +22,10 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to be interviewed, propose a topic for an episode, or help create the podcast itself!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
@@ -51,12 +51,12 @@ In this section, leave timestamped notes of the form:
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
 Audio Editing: alphastrata
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie){:target="_blank"}
 
-Hosts: [Ben Striegel](https://twitter.com/bstrie)
+Hosts: [Ben Striegel](https://twitter.com/bstrie){:target="_blank"}

--- a/_episodes/009-jan-lucio.md
+++ b/_episodes/009-jan-lucio.md
@@ -22,10 +22,10 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to be interviewed, propose a topic for an episode, or help with hosting or audio editing!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
@@ -54,12 +54,12 @@ In this section, leave timestamped notes of the form:
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Jeremy Jung](https://twitter.com/jertype)
+Audio Editing: [Jeremy Jung](https://twitter.com/jertype){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie/)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie/){:target="_blank"}
 
-Host: [Ben Striegel](https://twitter.com/bstrie/)
+Host: [Ben Striegel](https://twitter.com/bstrie/){:target="_blank"}

--- a/_episodes/010-rust-1.40.0.md
+++ b/_episodes/010-rust-1.40.0.md
@@ -10,7 +10,7 @@ reddit: https://www.reddit.com/r/rust/comments/eodj5d/whats_new_in_rust_140_rust
 guid: "rustacean-station/episode/010-rust-1.34.0/"
 ---
 
-Jon and Ben review the changes introduced in [Rust 1.40](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html).
+Jon and Ben review the changes introduced in [Rust 1.40](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html){:target="_blank"}.
 
 <!--
 The episode introduction goes here.
@@ -25,28 +25,28 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
-- [@00:52] - [`#[non_exhaustive]` structs, enums, and variants](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#[non_exhaustive]-structs,-enums,-and-variants)
-- [@12:31] - [Macro and attribute improvements](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#macro-and-attribute-improvements)
-    - [StackOverflow: How do I create a function-like procedural macro?](https://stackoverflow.com/questions/58922119/how-do-i-create-a-function-like-procedural-macro)
-- [@24:33] - [Borrow check migration warnings are hard errors in Rust 2015](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#borrow-check-migration-warnings-are-hard-errors-in-rust-2015)
-- [@25:21] - [More const fns in the standard library](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#macro-and-attribute-improvements)
-    - [`const-hack` issue label](https://github.com/rust-lang/rust/issues?q=label%3Aconst-hack)
-    - [Rustacean Station: Compile-Time Evaluation, Interpreted Rust, and UB Sanitizing: Talking to Oliver Scherer about Miri](https://rustacean-station.org/episode/008-oli-miri/)
-- [@28:31] - [The `todo!` macro](https://doc.rust-lang.org/std/macro.todo.html)
-- [@34:28] - [`slice::repeat`](https://doc.rust-lang.org/std/primitive.slice.html#method.repeat)
-- [@35:09] - [`mem::take`](https://doc.rust-lang.org/std/mem/fn.take.html)
-- [@36:55] - [`BTreeMap::get_key_value`](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html#method.get_key_value) and [`HashMap::get_key_value`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.get_key_value)
-    - [Ivan Dubrov: Tricking the HashMap](http://idubrov.name/rust/2018/06/01/tricking-the-hashmap.html)
+- [@00:52] - [`#[non_exhaustive]` structs, enums, and variants](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#[non_exhaustive]-structs,-enums,-and-variants){:target="_blank"}
+- [@12:31] - [Macro and attribute improvements](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#macro-and-attribute-improvements){:target="_blank"}
+    - [StackOverflow: How do I create a function-like procedural macro?](https://stackoverflow.com/questions/58922119/how-do-i-create-a-function-like-procedural-macro){:target="_blank"}
+- [@24:33] - [Borrow check migration warnings are hard errors in Rust 2015](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#borrow-check-migration-warnings-are-hard-errors-in-rust-2015){:target="_blank"}
+- [@25:21] - [More const fns in the standard library](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#macro-and-attribute-improvements){:target="_blank"}
+    - [`const-hack` issue label](https://github.com/rust-lang/rust/issues?q=label%3Aconst-hack){:target="_blank"}
+    - [Rustacean Station: Compile-Time Evaluation, Interpreted Rust, and UB Sanitizing: Talking to Oliver Scherer about Miri](https://rustacean-station.org/episode/008-oli-miri/){:target="_blank"}
+- [@28:31] - [The `todo!` macro](https://doc.rust-lang.org/std/macro.todo.html){:target="_blank"}
+- [@34:28] - [`slice::repeat`](https://doc.rust-lang.org/std/primitive.slice.html#method.repeat){:target="_blank"}
+- [@35:09] - [`mem::take`](https://doc.rust-lang.org/std/mem/fn.take.html){:target="_blank"}
+- [@36:55] - [`BTreeMap::get_key_value`](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html#method.get_key_value) and [`HashMap::get_key_value`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.get_key_value){:target="_blank"}
+    - [Ivan Dubrov: Tricking the HashMap](http://idubrov.name/rust/2018/06/01/tricking-the-hashmap.html){:target="_blank"}
 - [@40:24] - Standardized functions for converting floating-point types to byte arrays of specific endianness
-    - [Proposed Rust RFC: Standard lazy types](https://github.com/rust-lang/rfcs/pull/2788)
-    - [Rust PR: Stabilize the `matches!` macro](https://github.com/rust-lang/rust/pull/67659)
+    - [Proposed Rust RFC: Standard lazy types](https://github.com/rust-lang/rfcs/pull/2788){:target="_blank"}
+    - [Rust PR: Stabilize the `matches!` macro](https://github.com/rust-lang/rust/pull/67659){:target="_blank"}
 - [@45:55] - Cargo tweaks
 
 <!--
@@ -60,12 +60,12 @@ In this section, leave timestamped notes of the form:
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Jeremy Jung](https://twitter.com/jertype)
+Audio Editing: [Jeremy Jung](https://twitter.com/jertype){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie/)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie/){:target="_blank"}
 
 Hosts: Jon Gjengset and Ben Striegel

--- a/_episodes/011-jake-yoshua-stjepan.md
+++ b/_episodes/011-jake-yoshua-stjepan.md
@@ -7,7 +7,7 @@ length: "38682435"
 reddit: https://www.reddit.com/r/rust/comments/eslbuv/rustacean_station_triple_feature_rust_for_aaa/
 ---
 
-Three more interviews from RustFest 2019: [Jake Shadle](https://twitter.com/Ca1ne) on using Rust for high-performance game engines at [Embark](https://www.embark-studios.com/), applying lessons learned from working on EA DICE's Frostbite engine; [Yoshua Wuyts](https://twitter.com/yoshuawuyts) on `async-std` and Rust's async ecosystem; and [Stjepan Glavina](https://twitter.com/stjepang) on `crossbeam`, Rust's foundational library for powerful concurrency primitives.
+Three more interviews from RustFest 2019: [Jake Shadle](https://twitter.com/Ca1ne){:target="_blank"} on using Rust for high-performance game engines at [Embark](https://www.embark-studios.com/){:target="_blank"}, applying lessons learned from working on EA DICE's Frostbite engine; [Yoshua Wuyts](https://twitter.com/yoshuawuyts){:target="_blank"} on `async-std` and Rust's async ecosystem; and [Stjepan Glavina](https://twitter.com/stjepang){:target="_blank"} on `crossbeam`, Rust's foundational library for powerful concurrency primitives.
 
 ### Contributing to Rustacean Station
 
@@ -15,10 +15,10 @@ Three more interviews from RustFest 2019: [Jake Shadle](https://twitter.com/Ca1n
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
@@ -31,8 +31,8 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 - [@07:07] - Where is the Rust library ecosystem lacking for your use case, and what crates are you making use of?
 - [@11:13] - Why is Embark interested in WebAssembly?
 - [@14:20] - How can someone get in touch or learn more about Embark?
-    - [embark.dev](https://www.embark.dev/)
-    - [Inside Rust at Embark](https://medium.com/embarkstudios/inside-rust-at-embark-b82c06d1d9f4)
+    - [embark.dev](https://www.embark.dev/){:target="_blank"}
+    - [Inside Rust at Embark](https://medium.com/embarkstudios/inside-rust-at-embark-b82c06d1d9f4){:target="_blank"}
 
 #### [@15:09] Part 2: `async-std` w/ Yoshua Wuyts
 
@@ -40,14 +40,14 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 - [@17:12] - Is there anything from `async-std` that ought to be upstreamed into the standard library?
 - [@19:20] - Does `async-std` run into any conflicts with the types or traits defined in `futures-rs` or the standard library?
 - [@22:21] - How complete or incomplete is Rust's async ecosystem and async language support?
-    - [`async-trait`: a procedural macro for providing async trait methods on stable Rust](https://crates.io/crates/async-trait)
+    - [`async-trait`: a procedural macro for providing async trait methods on stable Rust](https://crates.io/crates/async-trait){:target="_blank"}
 - [@26:21] - How close is `async-std` to being a drop-in replacement for the standard library?
 - [@28:32] - What's next for the development of `async-std`?
 - [@30:07] - With the advent of `async-std` version 1.0, what would an eventual 2.0 release look like?
 - [@32:09] - Who is using `async-std`?
 - [@32:54] - How can someone get in touch or get involved?
-    - [async.rs](https://async.rs/)
-    - [github.com/async-rs](https://github.com/async-rs/)
+    - [async.rs](https://async.rs/){:target="_blank"}
+    - [github.com/async-rs](https://github.com/async-rs/){:target="_blank"}
 
 #### [@34:02] Part 3: `crossbeam` w/ Stjepan Glavina
 
@@ -65,12 +65,12 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Zoran Zaric](https://twitter.com/zoranzaric)
+Audio Editing: [Zoran Zaric](https://twitter.com/zoranzaric){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie/), [Zoran Zaric](https://twitter.com/zoranzaric)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie/), [Zoran Zaric](https://twitter.com/zoranzaric){:target="_blank"}
 
-Hosts: [Ben Striegel](https://twitter.com/bstrie/)
+Hosts: [Ben Striegel](https://twitter.com/bstrie/){:target="_blank"}

--- a/_episodes/012-pietro-pascal-santiago.md
+++ b/_episodes/012-pietro-pascal-santiago.md
@@ -7,7 +7,7 @@ length: "38542001"
 reddit: https://www.reddit.com/r/rust/comments/f0kpsx/rustacean_station_triple_feature_rust_release/
 ---
 
-Another trio of interviews from RustFest 2019: [Pietro Albini](https://twitter.com/pietroalbini) on Crater and the Rust Infrastructure Team; [Pascal Hertleif](https://twitter.com/killercup) on the Rust Developer Tools Team; and [Santiago Pastorino](https://twitter.com/spastorino) on the [Rust Latam](https://rustlatam.org/) conference in Latin America.
+Another trio of interviews from RustFest 2019: [Pietro Albini](https://twitter.com/pietroalbini){:target="_blank"} on Crater and the Rust Infrastructure Team; [Pascal Hertleif](https://twitter.com/killercup){:target="_blank"} on the Rust Developer Tools Team; and [Santiago Pastorino](https://twitter.com/spastorino) on the [Rust Latam](https://rustlatam.org/){:target="_blank"} conference in Latin America.
 
 <!--
 The episode introduction goes here.
@@ -22,10 +22,10 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
@@ -36,10 +36,10 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 - [@03:29] - How do you feel about potential future Rust editions in 2021 or beyond?
 - [@06:26] - Do you think Rust's regular release cycle too fast or too slow?
 - [@08:56] - How does Crater guard against language regressions, and what things doesn't it catch?
-    - [rust-lang/crater](https://github.com/rust-lang/crater)
+    - [rust-lang/crater](https://github.com/rust-lang/crater){:target="_blank"}
 - [@11:12] - How has Crater scaled as the ecosystem has grown, and is it at risk of becoming infeasible to run?
 - [@16:17] - How can someone get involved with the Infrastructure Team?
-    - [#infra Discord channel](https://discord.gg/AxXmxzN)
+    - [#infra Discord channel](https://discord.gg/AxXmxzN){:target="_blank"}
 
 #### [@17:25] Part 2: Developer Tools w/ Pascal Hertleif
 
@@ -47,14 +47,14 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 - [@19:39] - What tools is the Developer Tools Team responsible for, and what purposes do they serve?
 - [@24:46] - Which tools in particular would you like to draw attention to?
 - [@26:19] - How does rust-analyzer compare to RLS?
-    - [rust-lang/rls](https://github.com/rust-lang/rls)
-    - [rust-analyzer/rust-analyzer](https://github.com/rust-analyzer/rust-analyzer)
+    - [rust-lang/rls](https://github.com/rust-lang/rls){:target="_blank"}
+    - [rust-analyzer/rust-analyzer](https://github.com/rust-analyzer/rust-analyzer){:target="_blank"}
 - [@29:42] - How does the Developer Tools Team coordinate?
 - [@32:00] - How was your experience at RustFest this year?
 
 #### [@36:21] Part 3: Rust Latam w/ Santiago Pastorino
 
-- [@36:46] - What is [Rust Latam](https://rustlatam.org/)?
+- [@36:46] - What is [Rust Latam](https://rustlatam.org/){:target="_blank"}?
 - [@37:42] - What inspired you to start a Rust conference in Latin America?
 - [@39:06] - How big is Rust Latam?
 - [@40:15] - What is interest in Rust like in Latin America?
@@ -62,7 +62,7 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 - [@44:59] - What's next for Rust Latam?
 - [@45:42] - How did you get into Rust?
 - [@50:17] - What venues are there for Spanish or Portuguese-speaking Rust users?
-  - [Rust Brazilian Telegram Group](https://t.me/rustlangbr)
+  - [Rust Brazilian Telegram Group](https://t.me/rustlangbr){:target="_blank"}
 - [@51:34] - How can someone learn more about Rust Latam?
 
 <!--
@@ -76,12 +76,12 @@ In this section, leave timestamped notes of the form:
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Zoran Zaric](https://twitter.com/zoranzaric)
+Audio Editing: [Zoran Zaric](https://twitter.com/zoranzaric){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie/)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie/){:target="_blank"}
 
-Hosts: [Ben Striegel](https://twitter.com/bstrie/)
+Hosts: [Ben Striegel](https://twitter.com/bstrie/){:target="_blank"}

--- a/_episodes/013-rust-1.41.0.md
+++ b/_episodes/013-rust-1.41.0.md
@@ -7,7 +7,7 @@ length: "32615549"
 reddit: https://www.reddit.com/r/rust/comments/f6ghut/whats_new_in_rust_141_rustacean_station_podcast/
 ---
 
-Jon and Ben examine the features of [Rust 1.41](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html).
+Jon and Ben examine the features of [Rust 1.41](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html){:target="_blank"}.
 
 <!--
 The episode introduction goes here.
@@ -22,24 +22,24 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
-- [@02:39] - [Relaxed restrictions when implementing traits](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html#relaxed-restrictions-when-implementing-traits)
-- [@09:54] - [`cargo install` updates packages when outdated](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html#cargo-install-updates-packages-when-outdated)
-- [@12:20] - [Less conflict-prone Cargo.lock format](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html#less-conflict-prone-cargolock-format)
-- [@20:27] - [More guarantees when using `Box<T>` in FFI](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html#more-guarantees-when-using-boxt%3E-in-ffi)
-    - [Rust Unsafe Code Guidelines Working Group](https://github.com/rust-lang/unsafe-code-guidelines)
+- [@02:39] - [Relaxed restrictions when implementing traits](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html#relaxed-restrictions-when-implementing-traits){:target="_blank"}
+- [@09:54] - [`cargo install` updates packages when outdated](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html#cargo-install-updates-packages-when-outdated){:target="_blank"}
+- [@12:20] - [Less conflict-prone Cargo.lock format](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html#less-conflict-prone-cargolock-format){:target="_blank"}
+- [@20:27] - [More guarantees when using `Box<T>` in FFI](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html#more-guarantees-when-using-boxt%3E-in-ffi){:target="_blank"}
+    - [Rust Unsafe Code Guidelines Working Group](https://github.com/rust-lang/unsafe-code-guidelines){:target="_blank"}
 - [@26:22] - `NonZero*` numeric types now implement `From<NonZero*>` for smaller integer widths
-- [@30:40] - [Reducing support for 32-bit Apple targets soon](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html#reducing-support-for-32-bit-apple-targets-soon)
+- [@30:40] - [Reducing support for 32-bit Apple targets soon](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html#reducing-support-for-32-bit-apple-targets-soon){:target="_blank"}
 - [@31:47] - Compiler frontend support for constant propagation
-    - [Inside Rust Blog - Constant propagation is now on by default](https://blog.rust-lang.org/inside-rust/2019/12/02/const-prop-on-by-default.html)
-- [@35:06] - [Cargo profile overrides](https://doc.rust-lang.org/nightly/cargo/reference/profiles.html#overrides)
-- [@39:52] - [Nested custom `Self` receivers](https://github.com/rust-lang/rust/pull/64325)
+    - [Inside Rust Blog - Constant propagation is now on by default](https://blog.rust-lang.org/inside-rust/2019/12/02/const-prop-on-by-default.html){:target="_blank"}
+- [@35:06] - [Cargo profile overrides](https://doc.rust-lang.org/nightly/cargo/reference/profiles.html#overrides){:target="_blank"}
+- [@39:52] - [Nested custom `Self` receivers](https://github.com/rust-lang/rust/pull/64325){:target="_blank"}
 
 <!--
 In this section, leave timestamped notes of the form:
@@ -52,12 +52,12 @@ In this section, leave timestamped notes of the form:
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Zoran Zaric](https://twitter.com/zoranzaric)
+Audio Editing: [Zoran Zaric](https://twitter.com/zoranzaric){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie/)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie/){:target="_blank"}
 
 Hosts: Jon Gjengset and Ben Striegel

--- a/_episodes/014-rust-1.42-1.43.md
+++ b/_episodes/014-rust-1.42-1.43.md
@@ -25,75 +25,75 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
- - [@01:45] - [Useful line numbers on `unwrap`](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#useful-line-numbers-in-option-and-result-panic-messages)
-   - [`#[track_caller]`](https://github.com/rust-lang/rust/issues/47809)
- - [@04:22] - [Subslice patterns](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#subslice-patterns)
-   - [Stabilization report](https://github.com/rust-lang/rust/pull/67712/)
-   - [Ignoring with `..`](https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html#ignoring-remaining-parts-of-a-value-with-)
-   - [`@`-patterns](https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html#-bindings)
-   - [struct updates with `..`](https://doc.rust-lang.org/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax)
- - [@16:09] - [`matches!`](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#matches)
-   - [Macro documentation](https://doc.rust-lang.org/stable/std/macro.matches.html)
-   - [Jon proposes `assert_matches`](https://github.com/rust-lang/rust/issues/65721#issuecomment-566158398)
- - [@18:13] - [`Error::description` deprecation](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#errordescription-is-deprecated)
-   - [RFC](https://rust-lang.github.io/rfcs/2504-fix-error.html)
-   - [Soft deprecation in 1.27](https://github.com/rust-lang/rust/pull/50163)
-   - [`failure`](https://crates.io/crates/failure)
-   - [`thiserror`](https://crates.io/crates/thiserror)
-   - [`anyhow`](https://crates.io/crates/anyhow)
-   - [`eyre`](https://crates.io/crates/eyre)
-   - [Jane expermenting with `track_caller` in `eyre`](https://twitter.com/yaahc_/status/1253771822920634369)
- - [@24:23] - [Other changes in 1.42](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#other-changes)
-   - [Documentation improvements to cargo](https://github.com/rust-lang/cargo/pull/7733)
- - [@26:47] - [Rust 1.43](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html)
- - [@27:17] - [`item` macro fragments](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html#item-fragments) and parser improvements in general
-   - [More details about the problem](https://github.com/rust-lang/rust/issues/48137)
-   - [PR that fixed this](https://github.com/rust-lang/rust/pull/69366)
- - [@33:30] - [Primitive type inference](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html#type-inference-around-primitives)
+ - [@01:45] - [Useful line numbers on `unwrap`](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#useful-line-numbers-in-option-and-result-panic-messages){:target="_blank"}
+   - [`#[track_caller]`](https://github.com/rust-lang/rust/issues/47809){:target="_blank"}
+ - [@04:22] - [Subslice patterns](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#subslice-patterns){:target="_blank"}
+   - [Stabilization report](https://github.com/rust-lang/rust/pull/67712/){:target="_blank"}
+   - [Ignoring with `..`](https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html#ignoring-remaining-parts-of-a-value-with-){:target="_blank"}
+   - [`@`-patterns](https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html#-bindings){:target="_blank"}
+   - [struct updates with `..`](https://doc.rust-lang.org/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax){:target="_blank"}
+ - [@16:09] - [`matches!`](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#matches){:target="_blank"}
+   - [Macro documentation](https://doc.rust-lang.org/stable/std/macro.matches.html){:target="_blank"}
+   - [Jon proposes `assert_matches`](https://github.com/rust-lang/rust/issues/65721#issuecomment-566158398){:target="_blank"}
+ - [@18:13] - [`Error::description` deprecation](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#errordescription-is-deprecated){:target="_blank"}
+   - [RFC](https://rust-lang.github.io/rfcs/2504-fix-error.html){:target="_blank"}
+   - [Soft deprecation in 1.27](https://github.com/rust-lang/rust/pull/50163){:target="_blank"}
+   - [`failure`](https://crates.io/crates/failure){:target="_blank"}
+   - [`thiserror`](https://crates.io/crates/thiserror){:target="_blank"}
+   - [`anyhow`](https://crates.io/crates/anyhow){:target="_blank"}
+   - [`eyre`](https://crates.io/crates/eyre){:target="_blank"}
+   - [Jane expermenting with `track_caller` in `eyre`](https://twitter.com/yaahc_/status/1253771822920634369){:target="_blank"}
+ - [@24:23] - [Other changes in 1.42](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#other-changes){:target="_blank"}
+   - [Documentation improvements to cargo](https://github.com/rust-lang/cargo/pull/7733){:target="_blank"}
+ - [@26:47] - [Rust 1.43](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html){:target="_blank"}
+ - [@27:17] - [`item` macro fragments](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html#item-fragments){:target="_blank"} and parser improvements in general
+   - [More details about the problem](https://github.com/rust-lang/rust/issues/48137){:target="_blank"}
+   - [PR that fixed this](https://github.com/rust-lang/rust/pull/69366){:target="_blank"}
+ - [@33:30] - [Primitive type inference](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html#type-inference-around-primitives){:target="_blank"}
  - [@36:22] - Smaller changes surfacing in release notes
-   - [Steve Klabnik's blog post](https://words.steveklabnik.com/how-often-does-rust-change)
-   - [Rust 2020 roadmap on "finishing things"](https://github.com/rust-lang/rfcs/blob/master/text/2857-roadmap-2020.md#follow-through-with-in-progress-designs-and-efforts)
- - [@39:00] - [New cargo environment variables](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html#new-cargo-environment-variable-for-tests)
-   - [Cargo target directory](https://doc.rust-lang.org/cargo/reference/config.html#buildtarget-dir)
-   - [`assert_cmd`](https://crates.io/crates/assert_cmd)
-   - [Environment variables set by cargo](https://doc.rust-lang.org/nightly/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates)
- - [@43:39] - [Associated consts on numeric types](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html#library-changes)
+   - [Steve Klabnik's blog post](https://words.steveklabnik.com/how-often-does-rust-change){:target="_blank"}
+   - [Rust 2020 roadmap on "finishing things"](https://github.com/rust-lang/rfcs/blob/master/text/2857-roadmap-2020.md#follow-through-with-in-progress-designs-and-efforts){:target="_blank"}
+ - [@39:00] - [New cargo environment variables](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html#new-cargo-environment-variable-for-tests){:target="_blank"}
+   - [Cargo target directory](https://doc.rust-lang.org/cargo/reference/config.html#buildtarget-dir){:target="_blank"}
+   - [`assert_cmd`](https://crates.io/crates/assert_cmd){:target="_blank"}
+   - [Environment variables set by cargo](https://doc.rust-lang.org/nightly/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates){:target="_blank"}
+ - [@43:39] - [Associated consts on numeric types](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html#library-changes){:target="_blank"}
    - [Ben's RFC](https://github.com/rust-lang/rfcs/pull/2700)
    - [Issue from way back when](https://github.com/rust-lang/rfcs/issues/1099)
    - [The associated constants PR (2015)](https://github.com/rust-lang/rust/pull/23606)
    - [`max_value` PR (2015)](https://github.com/rust-lang/rust/pull/23947)
-   - [PR for Ben's RFC](https://github.com/rust-lang/rust/pull/68952/)
+   - [PR for Ben's RFC](https://github.com/rust-lang/rust/pull/68952/){:target="_blank"}
  - [@51:54] - What can we do in an edition?
-   - [`Error::source` RFC](https://rust-lang.github.io/rfcs/2504-fix-error.html)
- - [@54:20] - [The `primitive` module](https://doc.rust-lang.org/std/primitive/index.html)
-   - [`use` paths](https://doc.rust-lang.org/reference/items/use-declarations.html#use-paths)
-   - [The Rust prelude](https://doc.rust-lang.org/std/prelude/index.html)
-   - [Next edition prelude](https://github.com/rust-lang/rust/issues/65512)
- - [@57:50] - [`String` implements `AsMut<str>`](https://github.com/rust-lang/rust/pull/68742/)
- - [@59:40] - [cargo profile in config](https://doc.rust-lang.org/nightly/cargo/reference/config.html#profile)
-   - [cargo global configuration](https://doc.rust-lang.org/nightly/cargo/reference/config.html)
- - [@1:02:03] - [New feature resolver](https://github.com/rust-lang/cargo/pull/7820)
-   - [cargo merges features between dependency types](https://github.com/rust-lang/cargo/issues/4866)
- - [@1:05:30] - Lots of new clippy lints: [1.42](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-142), [1.43](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-143)
-   - [All the clippy lints](https://rust-lang.github.io/rust-clippy/master/index.html)
-   - [Pruning unwanted clippy lints](https://github.com/rust-lang/rust-clippy/issues/5418)
- - [@1:08:52] - [Rustfest postponed](https://blog.rustfest.eu/postponing-rustfest-nl)
+   - [`Error::source` RFC](https://rust-lang.github.io/rfcs/2504-fix-error.html){:target="_blank"}
+ - [@54:20] - [The `primitive` module](https://doc.rust-lang.org/std/primitive/index.html){:target="_blank"}
+   - [`use` paths](https://doc.rust-lang.org/reference/items/use-declarations.html#use-paths){:target="_blank"}
+   - [The Rust prelude](https://doc.rust-lang.org/std/prelude/index.html){:target="_blank"}
+   - [Next edition prelude](https://github.com/rust-lang/rust/issues/65512){:target="_blank"}
+ - [@57:50] - [`String` implements `AsMut<str>`](https://github.com/rust-lang/rust/pull/68742/){:target="_blank"}
+ - [@59:40] - [cargo profile in config](https://doc.rust-lang.org/nightly/cargo/reference/config.html#profile){:target="_blank"}
+   - [cargo global configuration](https://doc.rust-lang.org/nightly/cargo/reference/config.html){:target="_blank"}
+ - [@1:02:03] - [New feature resolver](https://github.com/rust-lang/cargo/pull/7820){:target="_blank"}
+   - [cargo merges features between dependency types](https://github.com/rust-lang/cargo/issues/4866){:target="_blank"}
+ - [@1:05:30] - Lots of new clippy lints: [1.42](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-142){:target="_blank"}, [1.43](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-143){:target="_blank"}
+   - [All the clippy lints](https://rust-lang.github.io/rust-clippy/master/index.html){:target="_blank"}
+   - [Pruning unwanted clippy lints](https://github.com/rust-lang/rust-clippy/issues/5418){:target="_blank"}
+ - [@1:08:52] - [Rustfest postponed](https://blog.rustfest.eu/postponing-rustfest-nl){:target="_blank"}
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [@alphastrata](https://twitter.com/alphastrata)
+Audio Editing: [@alphastrata](https://twitter.com/alphastrata){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Jon Gjengset](https://twitter.com/jonhoo/)
+Show Notes: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
 Hosts: Jon Gjengset and Ben Striegel

--- a/_episodes/015-twir-339.md
+++ b/_episodes/015-twir-339.md
@@ -22,27 +22,27 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced Resources
 
-- [This Week in Rust GitHub Repository](https://github.com/emberian/this-week-in-rust)
-- [Five Years of Rust](https://blog.rust-lang.org/2020/05/15/five-years-of-rust.html)
-- [The case for using Rust for Automotive Software](https://medium.com/@sojan.james/the-case-for-using-rust-for-automotive-software-19400779f126)
-- [Rust releases for single and multiple targets with GitHub Actions](https://mateuscosta.me/rust-releases-with-github-actions)
-- [Rust and C++ Cardiff Virtual Meetup](https://www.youtube.com/watch?v=s8WMaVU3EBs&feature=youtu.be)
-- [Jonathan Teaches Jason Rust!](https://www.youtube.com/watch?v=EzQ7YIIo1rY&feature=youtu.be)
-- [RFC: Transition to rust-analyzer as our official LSP (Language Server Protocol) implementation](https://github.com/rust-lang/rfcs/pull/2912)
-- [RFC: Reading into uninitialized buffers](https://github.com/rust-lang/rfcs/pull/2930)
+- [This Week in Rust GitHub Repository](https://github.com/emberian/this-week-in-rust){:target="_blank"}
+- [Five Years of Rust](https://blog.rust-lang.org/2020/05/15/five-years-of-rust.html){:target="_blank"}
+- [The case for using Rust for Automotive Software](https://medium.com/@sojan.james/the-case-for-using-rust-for-automotive-software-19400779f126){:target="_blank"}
+- [Rust releases for single and multiple targets with GitHub Actions](https://mateuscosta.me/rust-releases-with-github-actions){:target="_blank"}
+- [Rust and C++ Cardiff Virtual Meetup](https://www.youtube.com/watch?v=s8WMaVU3EBs&feature=youtu.be){:target="_blank"}
+- [Jonathan Teaches Jason Rust!](https://www.youtube.com/watch?v=EzQ7YIIo1rY&feature=youtu.be){:target="_blank"}
+- [RFC: Transition to rust-analyzer as our official LSP (Language Server Protocol) implementation](https://github.com/rust-lang/rfcs/pull/2912){:target="_blank"}
+- [RFC: Reading into uninitialized buffers](https://github.com/rust-lang/rfcs/pull/2930){:target="_blank"}
 
 
 ### Credits
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell)
+Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell){:target="_blank"}
 
 Hosts: Nell Shamrell-Harrington

--- a/_episodes/016-twir-340.md
+++ b/_episodes/016-twir-340.md
@@ -22,27 +22,27 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced resources
 
-- [Compiling Rust binaries for Windows 98 SE and more: a journey](https://seri.tools/blog/compiling-rust-for-legacy-windows/)]
-- [Conway's Game of Life on the NES in Rust](https://gridbugs.org/conways-game-of-life-on-the-nes-in-rust/)
-- [Writing Python inside your Rust code — Part 4](https://blog.m-ou.se/writing-python-inside-rust-4/)
-- [Zero To Production #0: Foreword](https://www.lpalmieri.com/posts/2020-05-24-zero-to-production-0-foreword/)
-- [How to organize your Rust tests](https://blog.logrocket.com/how-to-organize-your-rust-tests/)
-- [Rust Macro Rules in Practice](https://dev.to/sassman/rust-macro-rules-in-practice-40ne)
-- [Bringing WebAssembly outside the web with WASI by Lin Clark](https://www.youtube.com/watch?v=fh9WXPu0hw8)
-- [Microsoft's Safe Systems Programming Languages Effort](https://mybuild.microsoft.com/sessions/61de34c5-b111-4ece-928f-541854875862?source=sessions)
-- [3 Part Video for Beginners to Rust Programming on Iteration](https://tim.mcnamara.nz/post/618982870485172224/rust-iteration)
+- [Compiling Rust binaries for Windows 98 SE and more: a journey](https://seri.tools/blog/compiling-rust-for-legacy-windows/){:target="_blank"}
+- [Conway's Game of Life on the NES in Rust](https://gridbugs.org/conways-game-of-life-on-the-nes-in-rust/){:target="_blank"}
+- [Writing Python inside your Rust code — Part 4](https://blog.m-ou.se/writing-python-inside-rust-4/){:target="_blank"}
+- [Zero To Production #0: Foreword](https://www.lpalmieri.com/posts/2020-05-24-zero-to-production-0-foreword/){:target="_blank"}
+- [How to organize your Rust tests](https://blog.logrocket.com/how-to-organize-your-rust-tests/){:target="_blank"}
+- [Rust Macro Rules in Practice](https://dev.to/sassman/rust-macro-rules-in-practice-40ne){:target="_blank"}
+- [Bringing WebAssembly outside the web with WASI by Lin Clark](https://www.youtube.com/watch?v=fh9WXPu0hw8){:target="_blank"}
+- [Microsoft's Safe Systems Programming Languages Effort](https://mybuild.microsoft.com/sessions/61de34c5-b111-4ece-928f-541854875862?source=sessions){:target="_blank"}
+- [3 Part Video for Beginners to Rust Programming on Iteration](https://tim.mcnamara.nz/post/618982870485172224/rust-iteration){:target="_blank"}
 
 ### Credits
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell)
+Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell){:target="_blank"}
 
 Hosts: Nell Shamrell-Harrington

--- a/_episodes/017-twir-341-342.md
+++ b/_episodes/017-twir-341-342.md
@@ -22,57 +22,57 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced resources
 
 #### Issue 341
 
-- [This Week in Rust 341](https://this-week-in-rust.org/blog/2020/06/02/this-week-in-rust-341/)
-- [RustConf](https://rustconf.com/)
-- [Rust Contributor Survey](https://docs.google.com/forms/d/e/1FAIpQLSek3vddlYf3YFbV1RVavm9qAJhGxw-Zi_XJ8RBIhNUuuf34Pw/viewform)
-- [A Retrospective on the 2018 rust-lang.org redesign](https://blog.rust-lang.org/inside-rust/2020/05/26/website-retrospective.html)
-- [Contributing to Rust](https://blog.elinvynia.com/posts/2020-05-26-contributing-to-rust.html)
-- [How to build a WebSocket server with Rust](https://blog.logrocket.com/how-to-build-a-websocket-server-with-rust/)
-- [Custom Types in Diesel](https://kitsu.me/posts/2020_05_24_custom_types_in_diesel)
-- [Fuzzing Sequoia-PGP](https://blog.hackeriet.no/fuzzing-sequoia/)
-- [Sorting algorithms in Rust](https://dev.to/jlkiri/sorting-algorithms-in-rust-1386)
-- [3D boids swimming in perfect harmony: Implementing the boids flocking algorithm in Rust](https://www.reddit.com/r/rust/comments/gsldbi/3d_boids_swimming_along_in_perfect_harmony/)
-- [Aprende Rust en español](https://dev.to/robertohuertasm/aprende-rust-en-espanol-1pea)
-- [A Rust and WASM tutorial on building Bitcoin infrastructure](https://www.youtube.com/watch?v=qaykNPHJcyw)
-- [Crust of Rust: Iterators](https://www.youtube.com/watch?v=yozQ9C69pNs&feature=emb_logo)
-- [Rust and Tell Berlin - May 2020](https://www.youtube.com/watch?v=rpilJV-eIVw&feature=emb_logo)
+- [This Week in Rust 341](https://this-week-in-rust.org/blog/2020/06/02/this-week-in-rust-341/){:target="_blank"}
+- [RustConf](https://rustconf.com/){:target="_blank"}
+- [Rust Contributor Survey](https://docs.google.com/forms/d/e/1FAIpQLSek3vddlYf3YFbV1RVavm9qAJhGxw-Zi_XJ8RBIhNUuuf34Pw/viewform){:target="_blank"}
+- [A Retrospective on the 2018 rust-lang.org redesign](https://blog.rust-lang.org/inside-rust/2020/05/26/website-retrospective.html){:target="_blank"}
+- [Contributing to Rust](https://blog.elinvynia.com/posts/2020-05-26-contributing-to-rust.html){:target="_blank"}
+- [How to build a WebSocket server with Rust](https://blog.logrocket.com/how-to-build-a-websocket-server-with-rust/){:target="_blank"}
+- [Custom Types in Diesel](https://kitsu.me/posts/2020_05_24_custom_types_in_diesel){:target="_blank"}
+- [Fuzzing Sequoia-PGP](https://blog.hackeriet.no/fuzzing-sequoia/){:target="_blank"}
+- [Sorting algorithms in Rust](https://dev.to/jlkiri/sorting-algorithms-in-rust-1386){:target="_blank"}
+- [3D boids swimming in perfect harmony: Implementing the boids flocking algorithm in Rust](https://www.reddit.com/r/rust/comments/gsldbi/3d_boids_swimming_along_in_perfect_harmony/){:target="_blank"}
+- [Aprende Rust en español](https://dev.to/robertohuertasm/aprende-rust-en-espanol-1pea){:target="_blank"}
+- [A Rust and WASM tutorial on building Bitcoin infrastructure](https://www.youtube.com/watch?v=qaykNPHJcyw){:target="_blank"}
+- [Crust of Rust: Iterators](https://www.youtube.com/watch?v=yozQ9C69pNs&feature=emb_logo){:target="_blank"}
+- [Rust and Tell Berlin - May 2020](https://www.youtube.com/watch?v=rpilJV-eIVw&feature=emb_logo){:target="_blank"}
 
 #### Issue 342
 
-- [Announcing Rust 1.44.0](https://blog.rust-lang.org/2020/06/04/Rust-1.44.0.html)
-- [So What's Up with Microsoft's (and Everyone Else's) Love of Rust?](https://visualstudiomagazine.com/articles/2020/06/02/rust-love.aspx?m=1)
-- [Why the developers who use Rust love it so much](https://stackoverflow.blog/2020/06/05/why-the-developers-who-use-rust-love-it-so-much/?cb=1)
-- [Zero To Production #1: Setup - Toolchain, IDEs, CI](https://www.lpalmieri.com/posts/2020-06-06-zero-to-production-1-setup-toolchain-ides-ci/)
-- [This Month in Rust OSDev (May 2020)](https://rust-osdev.com/this-month/2020-05/)
-- [This Month in Rust GameDev #10 - May 2020](https://rust-gamedev.github.io/posts/newsletter-010/)
-- [This month in rustsim #11 (April - May 2020)](https://www.rustsim.org/blog/2020/06/01/this-month-in-rustsim/)
-- [RiB Newsletter #12 - ZK-Rustups](https://rustinblockchain.org/newsletters/2020-06-03-zk-rustups/)
-- [Graph & Tree Traversals in Rust](https://sachanganesh.com/programming/graph-tree-traversals-in-rust/)
-- [Memory-Safety Challenge Considered Solved? An Empirical Study with All Rust CVEs](https://arxiv.org/abs/2003.03296)
-- [Simple sorting algorithms in Rust](https://www.bilibili.com/read/cv4991161)
-- [Berbagai alasan melakukan Programming dalam Rust](https://dev.to/rizki96/berbagai-alasan-melakukan-programming-dalam-rust-p67)
-- [Rust Web development | Boilerplate free with Rocket](https://youtu.be/tjH0Mye8U_A)
-- [Educational Rust Live Coding - Building a web app - Part 4](https://www.youtube.com/watch?v=Dj8i3rM8FIQ)
-- [Iterators - Rust](https://www.youtube.com/watch?time_continue=1&v=HZftwxCIXqE&feature=emb_logo)
-- [Browser computation with WebAssembly Live Stream](https://www.twitch.tv/occupy_paul_st)
-- [Jonathan Teaches Jason Rust!](https://www.youtube.com/watch?v=Y5-ZgxfQvpc)
-- [Ruma-events project](https://github.com/ruma/ruma-events)
-- [Database project](https://alex-dukhno.github.io/2020-05-30-Writing-database-management-system-in-Rust.-When-the-flame-is-born-from-the-ashes/)
-- [Maud project](https://github.com/lambda-fairy/maud)
+- [Announcing Rust 1.44.0](https://blog.rust-lang.org/2020/06/04/Rust-1.44.0.html){:target="_blank"}
+- [So What's Up with Microsoft's (and Everyone Else's) Love of Rust?](https://visualstudiomagazine.com/articles/2020/06/02/rust-love.aspx?m=1){:target="_blank"}
+- [Why the developers who use Rust love it so much](https://stackoverflow.blog/2020/06/05/why-the-developers-who-use-rust-love-it-so-much/?cb=1){:target="_blank"}
+- [Zero To Production #1: Setup - Toolchain, IDEs, CI](https://www.lpalmieri.com/posts/2020-06-06-zero-to-production-1-setup-toolchain-ides-ci/){:target="_blank"}
+- [This Month in Rust OSDev (May 2020)](https://rust-osdev.com/this-month/2020-05/){:target="_blank"}
+- [This Month in Rust GameDev #10 - May 2020](https://rust-gamedev.github.io/posts/newsletter-010/){:target="_blank"}
+- [This month in rustsim #11 (April - May 2020)](https://www.rustsim.org/blog/2020/06/01/this-month-in-rustsim/){:target="_blank"}
+- [RiB Newsletter #12 - ZK-Rustups](https://rustinblockchain.org/newsletters/2020-06-03-zk-rustups/){:target="_blank"}
+- [Graph & Tree Traversals in Rust](https://sachanganesh.com/programming/graph-tree-traversals-in-rust/){:target="_blank"}
+- [Memory-Safety Challenge Considered Solved? An Empirical Study with All Rust CVEs](https://arxiv.org/abs/2003.03296){:target="_blank"}
+- [Simple sorting algorithms in Rust](https://www.bilibili.com/read/cv4991161){:target="_blank"}
+- [Berbagai alasan melakukan Programming dalam Rust](https://dev.to/rizki96/berbagai-alasan-melakukan-programming-dalam-rust-p67){:target="_blank"}
+- [Rust Web development | Boilerplate free with Rocket](https://youtu.be/tjH0Mye8U_A){:target="_blank"}
+- [Educational Rust Live Coding - Building a web app - Part 4](https://www.youtube.com/watch?v=Dj8i3rM8FIQ){:target="_blank"}
+- [Iterators - Rust](https://www.youtube.com/watch?time_continue=1&v=HZftwxCIXqE&feature=emb_logo){:target="_blank"}
+- [Browser computation with WebAssembly Live Stream](https://www.twitch.tv/occupy_paul_st){:target="_blank"}
+- [Jonathan Teaches Jason Rust!](https://www.youtube.com/watch?v=Y5-ZgxfQvpc){:target="_blank"}
+- [Ruma-events project](https://github.com/ruma/ruma-events){:target="_blank"}
+- [Database project](https://alex-dukhno.github.io/2020-05-30-Writing-database-management-system-in-Rust.-When-the-flame-is-born-from-the-ashes/){:target="_blank"}
+- [Maud project](https://github.com/lambda-fairy/maud){:target="_blank"}
 
 ### Credits
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell)
+Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell){:target="_blank"}
 
 Hosts: Nell Shamrell-Harrington

--- a/_episodes/018-twir-343.md
+++ b/_episodes/018-twir-343.md
@@ -22,30 +22,30 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced resources
 
-- [2020 Event Lineup - Update](https://blog.rust-lang.org/2020/06/10/event-lineup-update.html)
-- [Announcing RustFest Global 2020 🎉](https://blog.rustfest.eu/announcing-rustfest-2020)
-- [RustConf 2020 Registration is Open](https://rustconf.com/)
-- [Understanding the Rust Ecosystem](https://joeprevite.com/rust-lang-ecosystem)
-- [Errors in Rust: A Deep Dive](https://www.halcyon.hr/posts/error-handling-in-rust/)
-- [Getting Started With The STM32 Nucleo-F302R8 and Rust](https://blue42.net/code/rust/examples/embedded/nucleo-f30248/getting-started/post/)
-- [Rustls Security Review & Audit Report](https://github.com/ctz/rustls/blob/master/audit/TLS-01-report.pdf)
-- [audio] [AreWePodcastYet - Interview with Tim McNamara, author of Rust in Action](https://soundcloud.com/arewepodcastyet/awpy-05-tim-mcnamara-timclicks)
+- [2020 Event Lineup - Update](https://blog.rust-lang.org/2020/06/10/event-lineup-update.html){:target="_blank"}
+- [Announcing RustFest Global 2020 🎉](https://blog.rustfest.eu/announcing-rustfest-2020){:target="_blank"}
+- [RustConf 2020 Registration is Open](https://rustconf.com/){:target="_blank"}
+- [Understanding the Rust Ecosystem](https://joeprevite.com/rust-lang-ecosystem){:target="_blank"}
+- [Errors in Rust: A Deep Dive](https://www.halcyon.hr/posts/error-handling-in-rust/){:target="_blank"}
+- [Getting Started With The STM32 Nucleo-F302R8 and Rust](https://blue42.net/code/rust/examples/embedded/nucleo-f30248/getting-started/post/){:target="_blank"}
+- [Rustls Security Review & Audit Report](https://github.com/ctz/rustls/blob/master/audit/TLS-01-report.pdf){:target="_blank"}
+- [audio] [AreWePodcastYet - Interview with Tim McNamara, author of Rust in Action](https://soundcloud.com/arewepodcastyet/awpy-05-tim-mcnamara-timclicks){:target="_blank"}
 - [video] [Rust Notebooks (Jupyter and Evcxr) - Getting Started](https://www.youtube.com/watch?v=SZKEzNL9als)
-- [RFC: add the Freeze trait to libcore/libstd](https://github.com/rust-lang/rfcs/pull/2944)
-- [add Windows system error codes that should map to io::ErrorKind::TimedOut](https://github.com/rust-lang/rust/pull/71756)
-- [impl `PartialEq<Vec<B>> for &[A], &mut [A]`](https://github.com/rust-lang/rust/pull/71660)
+{:target="_blank"}- [RFC: add the Freeze trait to libcore/libstd](https://github.com/rust-lang/rfcs/pull/2944){:target="_blank"}
+- [add Windows system error codes that should map to io::ErrorKind::TimedOut](https://github.com/rust-lang/rust/pull/71756){:target="_blank"}
+- [impl `PartialEq<Vec<B>> for &[A], &mut [A]`](https://github.com/rust-lang/rust/pull/71660){:target="_blank"}
 
 ### Credits
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell)
+Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell){:target="_blank"}
 
 Hosts: Nell Shamrell-Harrington

--- a/_episodes/019-twir-344.md
+++ b/_episodes/019-twir-344.md
@@ -22,36 +22,36 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced resources
 
-* [Announcing Rust 1.44.1](https://blog.rust-lang.org/2020/06/18/Rust.1.44.1.html)
-* [Writing Non-Trivial Macros in Rust](http://adventures.michaelfbryan.com/posts/non-trivial-macros/)
-* [How to Design For Panic Resilience in Rust](https://towardsdatascience.com/how-to-design-for-panic-resilience-in-rust-55d5fd2478b9)
-* [Tour of Rust - Chapter 8 - Smart Pointers](https://tourofrust.com/chapter_8_en.html)
-* [Thread-local Storage - Part 13 of Making our own executable packer](https://fasterthanli.me/blog/2020/thread-local-storage/)
-* [RISC-V OS using Rust - Chapter 11](http://osblog.stephenmarz.com/ch11.html)
-* [Zero To Production #2: Learn By Building An Email Newsletter](https://www.lpalmieri.com/posts/2020-06-21-zero-to-production-2-learn-by-building-an-email-newsletter/)
-* [video] [Crust of Rust: Smart Pointers and Interior Mutability](https://www.youtube.com/watch?v=8O0Nt9qY_vo)
-* [video] [CS 196 at Illinois](https://www.youtube.com/channel/UCRA18QWPzB7FYVyg0WFKC6g/videos)
-* [video] [Rust Stream: The Guard Pattern and Interior Mutability](https://www.youtube.com/watch?v=lmEKIvLh9D4&feature=youtu.be)
-* [video] [Ask Me Anything with Felix Klock](https://www.youtube.com/watch?v=jGgQmnPH0dQ&feature=youtu.be&t=28792)
-* [GitUI](https://github.com/extrawurst/gitui)
-* [Ruma](https://github.com/ruma/ruma)
-* [RFC: 'C unwind' ABI](https://github.com/rust-lang/rfcs/pull/2945)
-* [impl `From<char>` for String](https://github.com/rust-lang/rust/pull/73466)
-* [stabilize leading_trailing_ones](https://github.com/rust-lang/rust/pull/73032)
-* [Add `TryFrom<{int}>` for `NonZero{int}`](https://github.com/rust-lang/rust/pull/72717)
-* [Stabilize `#[track_caller]`](https://github.com/rust-lang/rust/pull/72445)
+* [Announcing Rust 1.44.1](https://blog.rust-lang.org/2020/06/18/Rust.1.44.1.html){:target="_blank"}
+* [Writing Non-Trivial Macros in Rust](http://adventures.michaelfbryan.com/posts/non-trivial-macros/){:target="_blank"}
+* [How to Design For Panic Resilience in Rust](https://towardsdatascience.com/how-to-design-for-panic-resilience-in-rust-55d5fd2478b9){:target="_blank"}
+* [Tour of Rust - Chapter 8 - Smart Pointers](https://tourofrust.com/chapter_8_en.html){:target="_blank"}
+* [Thread-local Storage - Part 13 of Making our own executable packer](https://fasterthanli.me/blog/2020/thread-local-storage/){:target="_blank"}
+* [RISC-V OS using Rust - Chapter 11](http://osblog.stephenmarz.com/ch11.html){:target="_blank"}
+* [Zero To Production #2: Learn By Building An Email Newsletter](https://www.lpalmieri.com/posts/2020-06-21-zero-to-production-2-learn-by-building-an-email-newsletter/){:target="_blank"}
+* [video] [Crust of Rust: Smart Pointers and Interior Mutability](https://www.youtube.com/watch?v=8O0Nt9qY_vo){:target="_blank"}
+* [video] [CS 196 at Illinois](https://www.youtube.com/channel/UCRA18QWPzB7FYVyg0WFKC6g/videos){:target="_blank"}
+* [video] [Rust Stream: The Guard Pattern and Interior Mutability](https://www.youtube.com/watch?v=lmEKIvLh9D4&feature=youtu.be){:target="_blank"}
+* [video] [Ask Me Anything with Felix Klock](https://www.youtube.com/watch?v=jGgQmnPH0dQ&feature=youtu.be&t=28792){:target="_blank"}
+* [GitUI](https://github.com/extrawurst/gitui){:target="_blank"}
+* [Ruma](https://github.com/ruma/ruma){:target="_blank"}
+* [RFC: 'C unwind' ABI](https://github.com/rust-lang/rfcs/pull/2945){:target="_blank"}
+* [impl `From<char>` for String](https://github.com/rust-lang/rust/pull/73466){:target="_blank"}
+* [stabilize leading_trailing_ones](https://github.com/rust-lang/rust/pull/73032){:target="_blank"}
+* [Add `TryFrom<{int}>` for `NonZero{int}`](https://github.com/rust-lang/rust/pull/72717){:target="_blank"}
+* [Stabilize `#[track_caller]`](https://github.com/rust-lang/rust/pull/72445){:target="_blank"}
 
 ### Credits
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell)
+Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell){:target="_blank"}
 
 Hosts: Nell Shamrell-Harrington

--- a/_episodes/020-mun.md
+++ b/_episodes/020-mun.md
@@ -11,31 +11,31 @@ First time host, long time editor Jeremy talks with Bas and Remco, creators of t
 ### Contributing to Rustacean Station
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced resources
 
- - [The Mun Website](https://mun-lang.org/)
- - [The Mun github repo](https://github.com/mun-lang)
- - [Pull Requests](https://github.com/mun-lang/mun/issues/220)
- - [The Mozilla Grant](https://www.mozilla.org/en-US/moss/)
- - [The Amethyst Project](https://amethyst.rs/)
- - [The Mun community Discorrd](https://discordapp.com/channels/@me/536489746571198484/724567836097249290)
+ - [The Mun Website](https://mun-lang.org/){:target="_blank"}
+ - [The Mun github repo](https://github.com/mun-lang){:target="_blank"}
+ - [Pull Requests](https://github.com/mun-lang/mun/issues/220){:target="_blank"}
+ - [The Mozilla Grant](https://www.mozilla.org/en-US/moss/){:target="_blank"}
+ - [The Amethyst Project](https://amethyst.rs/){:target="_blank"}
+ - [The Mun community Discorrd](https://discordapp.com/channels/@me/536489746571198484/724567836097249290){:target="_blank"}
 
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Jeremy Webb](https://twitter.com/alphastrata) and [Jeremy Jung](https://www.softwaresessions.com/) Huge thanks to him for denoising the guests' tracks.
+Audio Editing: [Jeremy Webb](https://twitter.com/alphastrata){:target="_blank"} and [Jeremy Jung](https://www.softwaresessions.com/){:target="_blank"} Huge thanks to him for denoising the guests' tracks.
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
 Show Notes: Jeremy Webb 
 
 Hosts: Jeremy Webb 
 
-Guests: [Remco Kuijper](https://www.linkedin.com/in/remco-k-13a669ba/) and [Bas Zalmstra](https://www.linkedin.com/in/baszalmstra/)
+Guests: [Remco Kuijper](https://www.linkedin.com/in/remco-k-13a669ba/){:target="_blank"} and [Bas Zalmstra](https://www.linkedin.com/in/baszalmstra/){:target="_blank"}

--- a/_episodes/020-twir-345.md
+++ b/_episodes/020-twir-345.md
@@ -22,36 +22,36 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced resources
 
-* [Faster Rust Development on AWS EC2 with VSCode](https://dev.to/rimutaka/faster-rust-development-on-aws-ec2-with-vscode-4hno)
-* [Rust Verification Tools](https://alastairreid.github.io/rust-verification-tools/)
-* [Extremely Simple Rust Rocket Framework Tutorial](https://frogtok.com/extremely-simple-rust-rocket-framework-tutorial/)
-* [Build a Smart Bookmarking Tool with Rust and Rocket](https://developers.facebook.com/blog/post/2020/06/03/build-smart-bookmarking-tool-rust-rocket/)
-* [Secure Rust Guidelines](https://anssi-fr.github.io/rust-guide/)
-* [Examining ARM vs x86 Memory Models with Rust](https://www.nickwilcox.com/blog/arm_vs_x86_memory_model/)
-* [Rust Stream: Iterators](https://www.youtube.com/watch?v=lQt0adYPdfQ&feature=youtu.be)
-* [Manipulating ports, virtual ports and pseudo terminals](https://www.youtube.com/watch?v=_cYz03jS7tk&feature=youtu.be)
-* [Database Project](https://github.com/alex-dukhno/database)
-* [Gooseberry](https://github.com/out-of-cheese-error/gooseberry)
-* [Ruma](https://github.com/ruma/ruma)
-* [Crates.io token scopes](https://github.com/rust-lang/rfcs/pull/2947)
-* [Linking modifiers for native libraries](https://github.com/rust-lang/rfcs/pull/2951)
-* [Portable packed SIMD vector types](https://github.com/rust-lang/rfcs/pull/2948)
-* [Hierarchic anonymous life-time](https://github.com/rust-lang/rfcs/pull/2949)
-* [Inline `const` expressions and patterns](https://github.com/rust-lang/rfcs/pull/2920)
-* [Inline Assembly](https://github.com/rust-lang/rfcs/pull/2873)
-* [Deduplicate Cargo workspace information](https://github.com/rust-lang/rfcs/pull/2906)
+* [Faster Rust Development on AWS EC2 with VSCode](https://dev.to/rimutaka/faster-rust-development-on-aws-ec2-with-vscode-4hno){:target="_blank"}
+* [Rust Verification Tools](https://alastairreid.github.io/rust-verification-tools/){:target="_blank"}
+* [Extremely Simple Rust Rocket Framework Tutorial](https://frogtok.com/extremely-simple-rust-rocket-framework-tutorial/){:target="_blank"}
+* [Build a Smart Bookmarking Tool with Rust and Rocket](https://developers.facebook.com/blog/post/2020/06/03/build-smart-bookmarking-tool-rust-rocket/){:target="_blank"}
+* [Secure Rust Guidelines](https://anssi-fr.github.io/rust-guide/){:target="_blank"}
+* [Examining ARM vs x86 Memory Models with Rust](https://www.nickwilcox.com/blog/arm_vs_x86_memory_model/){:target="_blank"}
+* [Rust Stream: Iterators](https://www.youtube.com/watch?v=lQt0adYPdfQ&feature=youtu.be){:target="_blank"}
+* [Manipulating ports, virtual ports and pseudo terminals](https://www.youtube.com/watch?v=_cYz03jS7tk&feature=youtu.be){:target="_blank"}
+* [Database Project](https://github.com/alex-dukhno/database){:target="_blank"}
+* [Gooseberry](https://github.com/out-of-cheese-error/gooseberry){:target="_blank"}
+* [Ruma](https://github.com/ruma/ruma){:target="_blank"}
+* [Crates.io token scopes](https://github.com/rust-lang/rfcs/pull/2947){:target="_blank"}
+* [Linking modifiers for native libraries](https://github.com/rust-lang/rfcs/pull/2951){:target="_blank"}
+* [Portable packed SIMD vector types](https://github.com/rust-lang/rfcs/pull/2948){:target="_blank"}
+* [Hierarchic anonymous life-time](https://github.com/rust-lang/rfcs/pull/2949){:target="_blank"}
+* [Inline `const` expressions and patterns](https://github.com/rust-lang/rfcs/pull/2920){:target="_blank"}
+* [Inline Assembly](https://github.com/rust-lang/rfcs/pull/2873){:target="_blank"}
+* [Deduplicate Cargo workspace information](https://github.com/rust-lang/rfcs/pull/2906){:target="_blank"}
 
 ### Credits
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell)
+Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell){:target="_blank"}
 
 Hosts: Nell Shamrell-Harrington

--- a/_episodes/021-twir-346.md
+++ b/_episodes/021-twir-346.md
@@ -22,31 +22,31 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced resources
 
-* [Announcing Rustup 1.22.0](https://blog.rust-lang.org/2020/07/06/Rustup-1.22.0.html)
-* [Ownership of the standard library implementation](https://blog.rust-lang.org/inside-rust/2020/07/02/Ownership-Std-Implementation.html)
-* [Choosing a Rust web framework, 2020 edition](https://www.lpalmieri.com/posts/2020-07-04-choosing-a-rust-web-framework-2020-edition/)
-* [Simple Rocket Web Framework Tutorial POST Request](https://frogtok.com/simple-rocket-web-framework-tutorial-part-2in/)
-* [Transpiling a Kernel Module to Rust: The Good, the Bad and the Ugly](https://immunant.com/blog/2020/06/kernel_modules/)
-* [Ringbahn II: The Central State Machine](https://without.boats/blog/ringbahn-ii/)
-* [What is a Dangling Pointer?](https://medium.com/swlh/what-is-a-dangling-pointer-2773d49cf86c)
-* [Super Hero Rust fuzzing](https://blog.firosolutions.com/2020/07/superhero-rust-fuzzing/)
-* [RFC: IndexGet and IndexSet](https://github.com/rust-lang/rfcs/pull/2953)
-* [RFC: Add a new `#[instruction_set(...)]` attribute for supporting per-function instruction set changes](https://github.com/rust-lang/rfcs/pull/2867)
-* [Inline `const` expressions and patterns](https://github.com/rust-lang/rfcs/pull/2920)
-* [Inline Assembly](https://github.com/rust-lang/rfcs/pull/2873)
-* [This Week in Rust GitHub Repo](https://github.com/emberian/this-week-in-rust/)
+* [Announcing Rustup 1.22.0](https://blog.rust-lang.org/2020/07/06/Rustup-1.22.0.html){:target="_blank"}
+* [Ownership of the standard library implementation](https://blog.rust-lang.org/inside-rust/2020/07/02/Ownership-Std-Implementation.html){:target="_blank"}
+* [Choosing a Rust web framework, 2020 edition](https://www.lpalmieri.com/posts/2020-07-04-choosing-a-rust-web-framework-2020-edition/){:target="_blank"}
+* [Simple Rocket Web Framework Tutorial POST Request](https://frogtok.com/simple-rocket-web-framework-tutorial-part-2in/){:target="_blank"}
+* [Transpiling a Kernel Module to Rust: The Good, the Bad and the Ugly](https://immunant.com/blog/2020/06/kernel_modules/){:target="_blank"}
+* [Ringbahn II: The Central State Machine](https://without.boats/blog/ringbahn-ii/){:target="_blank"}
+* [What is a Dangling Pointer?](https://medium.com/swlh/what-is-a-dangling-pointer-2773d49cf86c){:target="_blank"}
+* [Super Hero Rust fuzzing](https://blog.firosolutions.com/2020/07/superhero-rust-fuzzing/){:target="_blank"}
+* [RFC: IndexGet and IndexSet](https://github.com/rust-lang/rfcs/pull/2953){:target="_blank"}
+* [RFC: Add a new `#[instruction_set(...)]` attribute for supporting per-function instruction set changes](https://github.com/rust-lang/rfcs/pull/2867){:target="_blank"}
+* [Inline `const` expressions and patterns](https://github.com/rust-lang/rfcs/pull/2920){:target="_blank"}
+* [Inline Assembly](https://github.com/rust-lang/rfcs/pull/2873){:target="_blank"}
+* [This Week in Rust GitHub Repo](https://github.com/emberian/this-week-in-rust/){:target="_blank"}
 
 ### Credits
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell)
+Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell){:target="_blank"}
 
 Hosts: Nell Shamrell-Harrington

--- a/_episodes/022-twir-347.md
+++ b/_episodes/022-twir-347.md
@@ -22,32 +22,32 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced resources
 
-- [Announcing Rustup 1.22.1](https://blog.rust-lang.org/2020/07/08/Rustup-1.22.1.html)
-- [Lang Team Design Meeting: Path to Membership](https://blog.rust-lang.org/inside-rust/2020/07/09/lang-team-path-to-membership.html)
-- [Perspective on Rust Community Moderation](https://www.reddit.com/r/rust/comments/hnfnti/where_is_the_rust_community_allowed_to_talk_about/fxf65nf/)
-- [The Soul of a New Debugger](https://nbaksalyar.github.io/2020/07/12/soul-of-a-new-debugger.html)
-- [Async Interview #8: Stjepan Glavina](https://smallcultfollowing.com/babysteps/blog/2020/07/09/async-interview-8-stjepan-glavina/)
-- [Using RabbitMQ in Rust](https://www.zupzup.org/rmq-in-rust/)
-- [Rust Analyzer Changelog #33](https://rust-analyzer.github.io/thisweek/2020/07/13/changelog-33.html)
-- [IntelliJ Rust Changelog #126](https://intellij-rust.github.io/2020/07/13/changelog-126.html)
-- [This Month in Rust OSDev](https://rust-osdev.com/this-month/2020-06/)
-- [Rust es orientado a objeto?](https://emanuelpeg.blogspot.com/2020/07/rust-es-orientado-objeto.html#.XwsegbMr_EQ.reddit)
-- [Fuzzing Rust with Shnatsel](https://medium.com/@social_62682/fuzzing-rust-with-shnatsel-podcast-e1fa0dbc28a)
-- [Two Sum Problem - Leet Code + Rust](https://www.youtube.com/watch?v=CMlHbAGkXjA&list=PLK_g1a_cAfaZuTXzDoQUAFEHCalKSCv9G&index=2)
-- [Rust and WebAssembly - EdgeXR @ Netlight](https://www.youtube.com/watch?v=dmbqpg5BuBY)
-- [Opt-in Stable Trait VTables](https://github.com/rust-lang/rfcs/pull/2955)
+- [Announcing Rustup 1.22.1](https://blog.rust-lang.org/2020/07/08/Rustup-1.22.1.html){:target="_blank"}
+- [Lang Team Design Meeting: Path to Membership](https://blog.rust-lang.org/inside-rust/2020/07/09/lang-team-path-to-membership.html){:target="_blank"}
+- [Perspective on Rust Community Moderation](https://www.reddit.com/r/rust/comments/hnfnti/where_is_the_rust_community_allowed_to_talk_about/fxf65nf/){:target="_blank"}
+- [The Soul of a New Debugger](https://nbaksalyar.github.io/2020/07/12/soul-of-a-new-debugger.html){:target="_blank"}
+- [Async Interview #8: Stjepan Glavina](https://smallcultfollowing.com/babysteps/blog/2020/07/09/async-interview-8-stjepan-glavina/){:target="_blank"}
+- [Using RabbitMQ in Rust](https://www.zupzup.org/rmq-in-rust/){:target="_blank"}
+- [Rust Analyzer Changelog #33](https://rust-analyzer.github.io/thisweek/2020/07/13/changelog-33.html){:target="_blank"}
+- [IntelliJ Rust Changelog #126](https://intellij-rust.github.io/2020/07/13/changelog-126.html){:target="_blank"}
+- [This Month in Rust OSDev](https://rust-osdev.com/this-month/2020-06/){:target="_blank"}
+- [Rust es orientado a objeto?](https://emanuelpeg.blogspot.com/2020/07/rust-es-orientado-objeto.html#.XwsegbMr_EQ.reddit){:target="_blank"}
+- [Fuzzing Rust with Shnatsel](https://medium.com/@social_62682/fuzzing-rust-with-shnatsel-podcast-e1fa0dbc28a){:target="_blank"}
+- [Two Sum Problem - Leet Code + Rust](https://www.youtube.com/watch?v=CMlHbAGkXjA&list=PLK_g1a_cAfaZuTXzDoQUAFEHCalKSCv9G&index=2){:target="_blank"}
+- [Rust and WebAssembly - EdgeXR @ Netlight](https://www.youtube.com/watch?v=dmbqpg5BuBY){:target="_blank"}
+- [Opt-in Stable Trait VTables](https://github.com/rust-lang/rfcs/pull/2955){:target="_blank"}
 
 ### Credits
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell)
+Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell){:target="_blank"}
 
 Hosts: Nell Shamrell-Harrington

--- a/_episodes/023-twir-348.md
+++ b/_episodes/023-twir-348.md
@@ -22,38 +22,38 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced resources
 
-- [Announcing Rust 1.45.0](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html)
-- [Learn how to make a Sokoban game in Rust](https://sokoban.iolivia.me/c01-00-intro.html)
-- [Clear Explanation of Rust’s module system](http://www.sheshbabu.com/posts/rust-module-system/)
-- [Rewriting FORTRAN Software in Rust](https://mckeogh.tech/post/shallow-water/)
-- [Writing a kernel driver with Rust](https://not-matthias.github.io/kernel-driver-with-rust/)
-- [Packaging and Vendoring Production Rust Software - Windows](https://ebbflow.io/blog/vending-win)
-- [Async Rust, but less intimidating](https://dev.to/dotxlem/async-rust-but-less-intimidating-2c13)
-- [Rust: What is Ownership and Borrowing](https://www.youtube.com/watch?v=79phqVpE7cU)
-- [Boiled Down Crate: OnceCell](https://www.youtube.com/watch?v=YBG8QTO8fNI&feature=youtu.be)
-- [Curso Rust](https://www.twitch.tv/videos/681897847)
-- [zbus is looking for contributors](https://gitlab.freedesktop.org/zeenix/zbus)
-- [just: Add extensible recipe and justfile attributes](https://github.com/casey/just/issues/604)
-- [libnet: Segfault in icmp send](https://github.com/libpnet/libpnet/issues/449)
-- [rust: fs::remove_dir_all rarely succeeds for large directories on window](https://github.com/rust-lang/rust/issues/29497)
-- [RFC: `C unwind` ABI](https://github.com/rust-lang/rfcs/pull/2945)
-- [Add `oneof` configuration predicate to support exclusive features](https://github.com/rust-lang/rfcs/pull/2962)
-- [RFC: Promote aarch64-unknown-linux-gnu to a Tier-1 Rust target](https://github.com/rust-lang/rfcs/pull/2959)
-- [Add Drop::poll_drop_ready for asynchronous destructors](https://github.com/rust-lang/rfcs/pull/2958)
-- [Stabilize Cargo's new feature resolver](https://github.com/rust-lang/rfcs/pull/2957)
-- [Add the partial-closure-args RFC](https://github.com/rust-lang/rfcs/pull/2956)
+- [Announcing Rust 1.45.0](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html){:target="_blank"}
+- [Learn how to make a Sokoban game in Rust](https://sokoban.iolivia.me/c01-00-intro.html){:target="_blank"}
+- [Clear Explanation of Rust’s module system](http://www.sheshbabu.com/posts/rust-module-system/){:target="_blank"}
+- [Rewriting FORTRAN Software in Rust](https://mckeogh.tech/post/shallow-water/){:target="_blank"}
+- [Writing a kernel driver with Rust](https://not-matthias.github.io/kernel-driver-with-rust/){:target="_blank"}
+- [Packaging and Vendoring Production Rust Software - Windows](https://ebbflow.io/blog/vending-win){:target="_blank"}
+- [Async Rust, but less intimidating](https://dev.to/dotxlem/async-rust-but-less-intimidating-2c13){:target="_blank"}
+- [Rust: What is Ownership and Borrowing](https://www.youtube.com/watch?v=79phqVpE7cU){:target="_blank"}
+- [Boiled Down Crate: OnceCell](https://www.youtube.com/watch?v=YBG8QTO8fNI&feature=youtu.be){:target="_blank"}
+- [Curso Rust](https://www.twitch.tv/videos/681897847){:target="_blank"}
+- [zbus is looking for contributors](https://gitlab.freedesktop.org/zeenix/zbus){:target="_blank"}
+- [just: Add extensible recipe and justfile attributes](https://github.com/casey/just/issues/604){:target="_blank"}
+- [libnet: Segfault in icmp send](https://github.com/libpnet/libpnet/issues/449){:target="_blank"}
+- [rust: fs::remove_dir_all rarely succeeds for large directories on window](https://github.com/rust-lang/rust/issues/29497){:target="_blank"}
+- [RFC: `C unwind` ABI](https://github.com/rust-lang/rfcs/pull/2945){:target="_blank"}
+- [Add `oneof` configuration predicate to support exclusive features](https://github.com/rust-lang/rfcs/pull/2962){:target="_blank"}
+- [RFC: Promote aarch64-unknown-linux-gnu to a Tier-1 Rust target](https://github.com/rust-lang/rfcs/pull/2959){:target="_blank"}
+- [Add Drop::poll_drop_ready for asynchronous destructors](https://github.com/rust-lang/rfcs/pull/2958){:target="_blank"}
+- [Stabilize Cargo's new feature resolver](https://github.com/rust-lang/rfcs/pull/2957){:target="_blank"}
+- [Add the partial-closure-args RFC](https://github.com/rust-lang/rfcs/pull/2956){:target="_blank"}
 
 ### Credits
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell)
+Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell){:target="_blank"}
 
 Hosts: Nell Shamrell-Harrington

--- a/_episodes/024-twir-349.md
+++ b/_episodes/024-twir-349.md
@@ -22,35 +22,35 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced resources
 
-* [This Week in Rust #349](https://this-week-in-rust.org/blog/2020/07/28/this-week-in-rust-349/)
-* [Opening up the Core Team agenda](https://blog.rust-lang.org/inside-rust/2020/07/27/opening-up-the-core-team-agenda.html)
-* [Rust's CI is Moving to GitHub Actions](https://blog.rust-lang.org/inside-rust/2020/07/23/rust-ci-is-moving-to-github-actions.html)
-* [IntelliJ Rust Changelog #127](https://intellij-rust.github.io/2020/07/27/changelog-127.html)
-* [Rust Analyzer Changelog #35](https://rust-analyzer.github.io/thisweek/2020/07/27/changelog-35.html)
-* [Notes on A Smaller Rust](https://without.boats/blog/notes-on-a-smaller-rust/)
-* [Rust Explained using Easy English](https://github.com/Dhghomon/easy_rust)
-* [Tutorial for Tokio and async Rust](https://tokio.rs/tokio/tutorial)
-* [Cell, RefCell, and Interior Mutability in Rust](https://badboi.dev/rust/2020/07/17/cell-refcell.html)
-* [Async/Await for AVR with Rust](https://lights0123.com/blog/2020/07/25/async-await-for-avr-with-rust/)
-* [Making a Game in 48 hours with Rust and WebAssembly](https://ianjk.com/rust-gamejam/)
-* [Inline assembly](https://github.com/rust-lang/rfcs/pull/2873)
+* [This Week in Rust #349](https://this-week-in-rust.org/blog/2020/07/28/this-week-in-rust-349/){:target="_blank"}
+* [Opening up the Core Team agenda](https://blog.rust-lang.org/inside-rust/2020/07/27/opening-up-the-core-team-agenda.html){:target="_blank"}
+* [Rust's CI is Moving to GitHub Actions](https://blog.rust-lang.org/inside-rust/2020/07/23/rust-ci-is-moving-to-github-actions.html){:target="_blank"}
+* [IntelliJ Rust Changelog #127](https://intellij-rust.github.io/2020/07/27/changelog-127.html){:target="_blank"}
+* [Rust Analyzer Changelog #35](https://rust-analyzer.github.io/thisweek/2020/07/27/changelog-35.html){:target="_blank"}
+* [Notes on A Smaller Rust](https://without.boats/blog/notes-on-a-smaller-rust/){:target="_blank"}
+* [Rust Explained using Easy English](https://github.com/Dhghomon/easy_rust){:target="_blank"}
+* [Tutorial for Tokio and async Rust](https://tokio.rs/tokio/tutorial){:target="_blank"}
+* [Cell, RefCell, and Interior Mutability in Rust](https://badboi.dev/rust/2020/07/17/cell-refcell.html){:target="_blank"}
+* [Async/Await for AVR with Rust](https://lights0123.com/blog/2020/07/25/async-await-for-avr-with-rust/){:target="_blank"}
+* [Making a Game in 48 hours with Rust and WebAssembly](https://ianjk.com/rust-gamejam/){:target="_blank"}
+* [Inline assembly](https://github.com/rust-lang/rfcs/pull/2873){:target="_blank"}
 * [Add a new `#[instruction_set(...)]` attribute for supporting per-function instruction set changes](https://github.com/rust-lang/rfcs/pull/2867)
-* [RFC: 'C unwind' ABI](https://github.com/rust-lang/rfcs/pull/2945)
-* [RFC: Add JSON backend to Rustdoc](https://github.com/rust-lang/rfcs/pull/2963)
-* [RFC: Named arguments](https://github.com/rust-lang/rfcs/pull/2964)
-* [Establish a new error handling project group](https://github.com/rust-lang/rfcs/pull/2965)
+{:target="_blank"}* [RFC: 'C unwind' ABI](https://github.com/rust-lang/rfcs/pull/2945){:target="_blank"}
+* [RFC: Add JSON backend to Rustdoc](https://github.com/rust-lang/rfcs/pull/2963){:target="_blank"}
+* [RFC: Named arguments](https://github.com/rust-lang/rfcs/pull/2964){:target="_blank"}
+* [Establish a new error handling project group](https://github.com/rust-lang/rfcs/pull/2965){:target="_blank"}
 
 ### Credits
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell)
+Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell){:target="_blank"}
 
 Hosts: Nell Shamrell-Harrington

--- a/_episodes/025-katharina-florian.md
+++ b/_episodes/025-katharina-florian.md
@@ -7,7 +7,7 @@ length: "35318701"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
 
-Two more long-awaited interviews from RustFest 2019: [Katharina Fey](https://twitter.com/spacekookie) on the phenomenon of burnout in software and in open source communities and [Florian Gilcher](https://twitter.com/Argorak) on Rust's annual roadmaps.
+Two more long-awaited interviews from RustFest 2019: [Katharina Fey](https://twitter.com/spacekookie){:target="_blank"} on the phenomenon of burnout in software and in open source communities and [Florian Gilcher](https://twitter.com/Argorak){:target="_blank"} on Rust's annual roadmaps.
 
 <!--
 The episode introduction goes here.
@@ -22,10 +22,10 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
@@ -39,15 +39,15 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 
 #### [@19:50] Part 2: The Rust Roadmap w/ Florian Gilcher
 
- - [Rust 2019 roadmap](https://blog.rust-lang.org/2019/04/23/roadmap.html)
- - [Rust 2020 roadmap](https://github.com/rust-lang/rfcs/blob/master/text/2857-roadmap-2020.md)
+ - [Rust 2019 roadmap](https://blog.rust-lang.org/2019/04/23/roadmap.html){:target="_blank"}
+ - [Rust 2020 roadmap](https://github.com/rust-lang/rfcs/blob/master/text/2857-roadmap-2020.md){:target="_blank"}
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Eddy Petrisor](https://twitter.com/eddypetrisor)
+Audio Editing: [Eddy Petrisor](https://twitter.com/eddypetrisor){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie){:target="_blank"}

--- a/_episodes/026-twir-350.md
+++ b/_episodes/026-twir-350.md
@@ -22,34 +22,34 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced resources
 
-* [Announcing Rust 1.45.1](https://blog.rust-lang.org/2020/07/30/Rust-1.45.1.html)
-* [Announcing Rust 1.45.2](https://blog.rust-lang.org/2020/08/03/Rust-1.45.2.html)
-* [Headcrab: July 2020 progress report](https://headcrab.rs/2020/07/31/july-update.html)
+* [Announcing Rust 1.45.1](https://blog.rust-lang.org/2020/07/30/Rust-1.45.1.html){:target="_blank"}
+* [Announcing Rust 1.45.2](https://blog.rust-lang.org/2020/08/03/Rust-1.45.2.html){:target="_blank"}
+* [Headcrab: July 2020 progress report](https://headcrab.rs/2020/07/31/july-update.html){:target="_blank"}
 * [This Month in Rust OSDev (July 2020)](https://rust-osdev.com/this-month/2020-07/)
-* [Learning Rust: Mindsets and Expectations](https://ferrous-systems.com/blog/mindsets-and-expectations/)
-* [Blue Team Rust: What is "Memory Safety", really?](https://tiemoko.com/blog/blue-team-rust/)
+{:target="_blank"}* [Learning Rust: Mindsets and Expectations](https://ferrous-systems.com/blog/mindsets-and-expectations/){:target="_blank"}
+* [Blue Team Rust: What is "Memory Safety", really?](https://tiemoko.com/blog/blue-team-rust/){:target="_blank"}
 * [Creating Linux Packages for Rust Projects (1/2)](https://ebbflow.io/blog/vending-linux-1)
-* [Reverse Engineering a USB Device with Rust](https://gill.net.in/posts/reverse-engineering-a-usb-device-with-rust/)
-* [Some Learnings from Implementing a Normalizing Rust Representer](https://seanchen1991.github.io/posts/rust-representer/)
-* [video][Learning Rust by Working Through the Rustlings Exercises](https://egghead.io/playlists/learning-rust-by-solving-the-rustlings-exercises-a722)
-* [Rust Language Cheat Sheet 2019 -> 2020](https://github.com/ralfbiedert/cheats.rs/issues/100)
-* [audio][The State of Rust 2 with Alex Chrichton](https://anchor.fm/the-virtual-world/episodes/Ep-7--The-State-of-Rust-2-with-Alex-Crichton-ehjpsq)
-* [audio][The State of Rust with Steve Klabnik](https://anchor.fm/the-virtual-world/episodes/Ep-6--The-State-of-Rust-with-Steve-Klabnik-ehf8mk)
-* [RFC: 'C unwind' ABI](https://github.com/rust-lang/rfcs/pull/2945)
-* [Procedural vtables and wide ptr metadata](https://github.com/rust-lang/rfcs/pull/2967)
-* [Edition 2021 and beyond](https://github.com/rust-lang/rfcs/pull/2966)
+{:target="_blank"}* [Reverse Engineering a USB Device with Rust](https://gill.net.in/posts/reverse-engineering-a-usb-device-with-rust/){:target="_blank"}
+* [Some Learnings from Implementing a Normalizing Rust Representer](https://seanchen1991.github.io/posts/rust-representer/){:target="_blank"}
+* [video][Learning Rust by Working Through the Rustlings Exercises](https://egghead.io/playlists/learning-rust-by-solving-the-rustlings-exercises-a722){:target="_blank"}
+* [Rust Language Cheat Sheet 2019 -> 2020](https://github.com/ralfbiedert/cheats.rs/issues/100){:target="_blank"}
+* [audio][The State of Rust 2 with Alex Chrichton](https://anchor.fm/the-virtual-world/episodes/Ep-7--The-State-of-Rust-2-with-Alex-Crichton-ehjpsq){:target="_blank"}
+* [audio][The State of Rust with Steve Klabnik](https://anchor.fm/the-virtual-world/episodes/Ep-6--The-State-of-Rust-with-Steve-Klabnik-ehf8mk){:target="_blank"}
+* [RFC: 'C unwind' ABI](https://github.com/rust-lang/rfcs/pull/2945){:target="_blank"}
+* [Procedural vtables and wide ptr metadata](https://github.com/rust-lang/rfcs/pull/2967){:target="_blank"}
+* [Edition 2021 and beyond](https://github.com/rust-lang/rfcs/pull/2966){:target="_blank"}
 
 ### Credits
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell)
+Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell){:target="_blank"}
 
 Hosts: Nell Shamrell-Harrington

--- a/_episodes/027-twir-351.md
+++ b/_episodes/027-twir-351.md
@@ -22,34 +22,34 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced resources
 
-* [Announcing Rust 1.45.1](https://blog.rust-lang.org/2020/07/30/Rust-1.45.1.html)
-* [Announcing Rust 1.45.2](https://blog.rust-lang.org/2020/08/03/Rust-1.45.2.html)
-* [Headcrab: July 2020 progress report](https://headcrab.rs/2020/07/31/july-update.html)
+* [Announcing Rust 1.45.1](https://blog.rust-lang.org/2020/07/30/Rust-1.45.1.html){:target="_blank"}
+* [Announcing Rust 1.45.2](https://blog.rust-lang.org/2020/08/03/Rust-1.45.2.html){:target="_blank"}
+* [Headcrab: July 2020 progress report](https://headcrab.rs/2020/07/31/july-update.html){:target="_blank"}
 * [This Month in Rust OSDev (July 2020)](https://rust-osdev.com/this-month/2020-07/)
-* [Learning Rust: Mindsets and Expectations](https://ferrous-systems.com/blog/mindsets-and-expectations/)
-* [Blue Team Rust: What is "Memory Safety", really?](https://tiemoko.com/blog/blue-team-rust/)
+{:target="_blank"}* [Learning Rust: Mindsets and Expectations](https://ferrous-systems.com/blog/mindsets-and-expectations/){:target="_blank"}
+* [Blue Team Rust: What is "Memory Safety", really?](https://tiemoko.com/blog/blue-team-rust/){:target="_blank"}
 * [Creating Linux Packages for Rust Projects (1/2)](https://ebbflow.io/blog/vending-linux-1)
-* [Reverse Engineering a USB Device with Rust](https://gill.net.in/posts/reverse-engineering-a-usb-device-with-rust/)
-* [Some Learnings from Implementing a Normalizing Rust Representer](https://seanchen1991.github.io/posts/rust-representer/)
-* [video][Learning Rust by Working Through the Rustlings Exercises](https://egghead.io/playlists/learning-rust-by-solving-the-rustlings-exercises-a722)
-* [Rust Language Cheat Sheet 2019 -> 2020](https://github.com/ralfbiedert/cheats.rs/issues/100)
-* [audio][The State of Rust 2 with Alex Chrichton](https://anchor.fm/the-virtual-world/episodes/Ep-7--The-State-of-Rust-2-with-Alex-Crichton-ehjpsq)
-* [audio][The State of Rust with Steve Klabnik](https://anchor.fm/the-virtual-world/episodes/Ep-6--The-State-of-Rust-with-Steve-Klabnik-ehf8mk)
-* [RFC: 'C unwind' ABI](https://github.com/rust-lang/rfcs/pull/2945)
-* [Procedural vtables and wide ptr metadata](https://github.com/rust-lang/rfcs/pull/2967)
-* [Edition 2021 and beyond](https://github.com/rust-lang/rfcs/pull/2966)
+{:target="_blank"}* [Reverse Engineering a USB Device with Rust](https://gill.net.in/posts/reverse-engineering-a-usb-device-with-rust/){:target="_blank"}
+* [Some Learnings from Implementing a Normalizing Rust Representer](https://seanchen1991.github.io/posts/rust-representer/){:target="_blank"}
+* [video][Learning Rust by Working Through the Rustlings Exercises](https://egghead.io/playlists/learning-rust-by-solving-the-rustlings-exercises-a722){:target="_blank"}
+* [Rust Language Cheat Sheet 2019 -> 2020](https://github.com/ralfbiedert/cheats.rs/issues/100){:target="_blank"}
+* [audio][The State of Rust 2 with Alex Chrichton](https://anchor.fm/the-virtual-world/episodes/Ep-7--The-State-of-Rust-2-with-Alex-Crichton-ehjpsq){:target="_blank"}
+* [audio][The State of Rust with Steve Klabnik](https://anchor.fm/the-virtual-world/episodes/Ep-6--The-State-of-Rust-with-Steve-Klabnik-ehf8mk){:target="_blank"}
+* [RFC: 'C unwind' ABI](https://github.com/rust-lang/rfcs/pull/2945){:target="_blank"}
+* [Procedural vtables and wide ptr metadata](https://github.com/rust-lang/rfcs/pull/2967){:target="_blank"}
+* [Edition 2021 and beyond](https://github.com/rust-lang/rfcs/pull/2966){:target="_blank"}
 
 ### Credits
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell)
+Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell){:target="_blank"}
 
 Hosts: Nell Shamrell-Harrington

--- a/_episodes/028-rust-1.44-1.45.md
+++ b/_episodes/028-rust-1.44-1.45.md
@@ -23,29 +23,29 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
-#### [@01:21] - [Rust 1.44](https://blog.rust-lang.org/2020/06/04/Rust-1.44.0.html) ([Detailed Release Notes](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1440-2020-06-04))
+#### [@01:21] - [Rust 1.44](https://blog.rust-lang.org/2020/06/04/Rust-1.44.0.html){:target="_blank"} ([Detailed Release Notes](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1440-2020-06-04){:target="_blank"})
 
- - [@01:50] - [`cargo tree` subcommand](https://github.com/rust-lang/cargo/pull/8062/)
- - [@04:52] - [`async`/`await` in `#[no_std]` contexts](https://github.com/rust-lang/rust/pull/69033/)
- - [@12:16] - [Unicode 13 is now supported](https://github.com/rust-lang/rust/pull/69929/)
- - [@17:16] - [rustc now respects the -C codegen-units flag in incremental mode](https://github.com/rust-lang/rust/pull/70156/)
+ - [@01:50] - [`cargo tree` subcommand](https://github.com/rust-lang/cargo/pull/8062/){:target="_blank"}
+ - [@04:52] - [`async`/`await` in `#[no_std]` contexts](https://github.com/rust-lang/rust/pull/69033/){:target="_blank"}
+ - [@12:16] - [Unicode 13 is now supported](https://github.com/rust-lang/rust/pull/69929/){:target="_blank"}
+ - [@17:16] - [rustc now respects the -C codegen-units flag in incremental mode](https://github.com/rust-lang/rust/pull/70156/){:target="_blank"}
  - [@18:47] - [Special cased `vec![]` to map directly to `Vec::new()`](https://github.com/rust-lang/rust/pull/70632/)
+{:target="_blank"}
+#### [@28:51] - [Rust 1.45](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html){:target="_blank"}
 
-#### [@28:51] - [Rust 1.45](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html)
+ - [@29:14] - [Fixing an unsoundness in float to integer casts](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html#fixing-unsoundness-in-casts){:target="_blank"}
+ - [@39:16] - [Stabilizing function-like procedural macros in expressions, patterns, and statements](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html#stabilizing-function-like-procedural-macros-in-expressions-patterns-and-statements){:target="_blank"}
+ - [@43:29] - [`str::strip_prefix`](https://doc.rust-lang.org/std/primitive.str.html#method.strip_prefix){:target="_blank"} and [`str::strip_suffix`](https://doc.rust-lang.org/std/primitive.str.html#method.strip_suffix){:target="_blank"}
 
- - [@29:14] - [Fixing an unsoundness in float to integer casts](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html#fixing-unsoundness-in-casts)
- - [@39:16] - [Stabilizing function-like procedural macros in expressions, patterns, and statements](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html#stabilizing-function-like-procedural-macros-in-expressions-patterns-and-statements)
- - [@43:29] - [`str::strip_prefix`](https://doc.rust-lang.org/std/primitive.str.html#method.strip_prefix) and [`str::strip_suffix`](https://doc.rust-lang.org/std/primitive.str.html#method.strip_suffix)
-
- - Bonus: [Opening up the Rust Core Team agenda](https://blog.rust-lang.org/inside-rust/2020/07/27/opening-up-the-core-team-agenda.html)
-   - See also: [The Inside Rust Blog](https://blog.rust-lang.org/inside-rust/index.html)
+ - Bonus: [Opening up the Rust Core Team agenda](https://blog.rust-lang.org/inside-rust/2020/07/27/opening-up-the-core-team-agenda.html){:target="_blank"}
+   - See also: [The Inside Rust Blog](https://blog.rust-lang.org/inside-rust/index.html){:target="_blank"}
 
 <!--
 In this section, leave timestamped notes of the form:
@@ -58,12 +58,12 @@ In this section, leave timestamped notes of the form:
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Jeremy Jung](https://www.softwaresessions.com/)
+Audio Editing: [Jeremy Jung](https://www.softwaresessions.com/){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie){:target="_blank"}
 
 Hosts: Jon Gjengset and Ben Striegel

--- a/_episodes/028-twir-352.md
+++ b/_episodes/028-twir-352.md
@@ -22,28 +22,28 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Referenced resources
 
-* [Laying the foundation for Rust's future](https://blog.rust-lang.org/2020/08/18/laying-the-foundation-for-rusts-future.html)
-* [Learning Rust: The Compiler is your Friend](https://ferrous-systems.com/blog/the-compiler-is-your-friend/)
-* [Why Rust is a great fit for embedded software](https://tweedegolf.nl/blog/39/why-rust-is-a-great-fit-for-embedded-software)
-* [Why Rust's Unsafe Works](https://jam1.re/blog/why-rusts-unsafe-works)
-* [I am a Java, C#, C or C++ developer, time to do some Rust](https://fasterthanli.me/articles/i-am-a-java-csharp-c-or-cplusplus-dev-time-to-do-some-rust)
-* [Async Unicorns love Rust](https://blog.kdubovikov.ml/articles/rust/async-unicorns-love-rust)
+* [Laying the foundation for Rust's future](https://blog.rust-lang.org/2020/08/18/laying-the-foundation-for-rusts-future.html){:target="_blank"}
+* [Learning Rust: The Compiler is your Friend](https://ferrous-systems.com/blog/the-compiler-is-your-friend/){:target="_blank"}
+* [Why Rust is a great fit for embedded software](https://tweedegolf.nl/blog/39/why-rust-is-a-great-fit-for-embedded-software){:target="_blank"}
+* [Why Rust's Unsafe Works](https://jam1.re/blog/why-rusts-unsafe-works){:target="_blank"}
+* [I am a Java, C#, C or C++ developer, time to do some Rust](https://fasterthanli.me/articles/i-am-a-java-csharp-c-or-cplusplus-dev-time-to-do-some-rust){:target="_blank"}
+* [Async Unicorns love Rust](https://blog.kdubovikov.ml/articles/rust/async-unicorns-love-rust){:target="_blank"}
 * [Linux Packages For Rust (2/3) - Building with GitHub Actions using Custom Actions and Docker Container Images](https://ebbflow.io/blog/vending-linux-2)
-* [Rust RFCs Repo](https://github.com/rust-lang/rfcs)
-* [RustConf](https://rustconf.com/)
-* [This Week in Rust GitHub Repo](https://github.com/emberian/this-week-in-rust/)
+{:target="_blank"}* [Rust RFCs Repo](https://github.com/rust-lang/rfcs){:target="_blank"}
+* [RustConf](https://rustconf.com/){:target="_blank"}
+* [This Week in Rust GitHub Repo](https://github.com/emberian/this-week-in-rust/){:target="_blank"}
 
 ### Credits
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell)
+Show Notes: [Nell Shamrell-Harrington](https://twitter.com/nellshamrell){:target="_blank"}
 
 Hosts: Nell Shamrell-Harrington

--- a/_episodes/029-redisjson.md
+++ b/_episodes/029-redisjson.md
@@ -14,10 +14,10 @@ Jeremy talks with Christoph Zimmermann about Redislabs' new JSON module, which i
 
 Rustacean Station is a community project; get in touch with us if you'd like to be interviewed, propose a topic for an episode, or help create the podcast itself!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps 
 
@@ -47,21 +47,21 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 
 ### Referenced Resources
 
-- [Christoph's Podcast](https://linuxinlaws.eu/)
-- [Christoph's FOSDEM Talk](https://ftp.osuosl.org/pub/fosdem/2020/K.3.401/rust_redisjson.webm)
-- [RedisJSON on GitHub](https://github.com/RedisJSON/RedisJSON2)
-- [Redislabs](https://university.redislabs.com/)
+- [Christoph's Podcast](https://linuxinlaws.eu/){:target="_blank"}
+- [Christoph's FOSDEM Talk](https://ftp.osuosl.org/pub/fosdem/2020/K.3.401/rust_redisjson.webm){:target="_blank"}
+- [RedisJSON on GitHub](https://github.com/RedisJSON/RedisJSON2){:target="_blank"}
+- [Redislabs](https://university.redislabs.com/){:target="_blank"}
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Cole](https://twitch.tv/refactorordie)
+Audio Editing: [Cole](https://twitch.tv/refactorordie){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
 Show Notes: Cole and Jeremy Webb 
 
 Hosts: Jeremy Webb 
 
-Guests: [Chrisoph Zimmermann](https://twitter.com/7immermann/)
+Guests: [Chrisoph Zimmermann](https://twitter.com/7immermann/){:target="_blank"}

--- a/_episodes/030-krustlet.md
+++ b/_episodes/030-krustlet.md
@@ -8,16 +8,16 @@ length: "59390302"
 
 ---
 
-[Taylor Thomas](https://twitter.com/_oftaylor) explains how [Krustlet](https://github.com/deislabs/krustlet) runs WebAssembly modules in Kubernetes and why it's a promising option for the future of server side applications.
+[Taylor Thomas](https://twitter.com/_oftaylor){:target="_blank"} explains how [Krustlet](https://github.com/deislabs/krustlet){:target="_blank"} runs WebAssembly modules in Kubernetes and why it's a promising option for the future of server side applications.
 
 ### Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to be interviewed, propose a topic for an episode, or help create the podcast itself!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps 
 
@@ -35,29 +35,29 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 
 ### Referenced Resources
 
-- [Krustlet](https://github.com/deislabs/krustlet)
-- [Kubernetes](https://kubernetes.io/)
-- [Open Container Initiative](https://opencontainers.org/)
-- [WebAssembly](https://webassembly.org/)
-- [WASI](https://wasi.dev/)
-- [Wasmtime](https://wasmtime.dev/)
-- [waSCC](https://wascc.dev/)
-- [WebAssembly meets Kubernetes with Krustlet](https://cloudblogs.microsoft.com/opensource/2020/04/07/announcing-krustlet-kubernetes-rust-kubelet-webassembly-wasm/)
-- [Introducing Krustlet, the WebAssembly Kubelet](https://deislabs.io/posts/introducing-krustlet/)
-- [Kubernetes: A Rusty Friendship](https://deislabs.io/posts/kubernetes-a-rusty-friendship/)
-- [The Safety Boat: Kubernetes and Rust](https://msrc-blog.microsoft.com/2020/04/29/the-safety-boat-kubernetes-and-rust/)
-- [A Heaping Helping of Stacks](https://deislabs.io/posts/a-heaping-helping-of-stacks/)
+- [Krustlet](https://github.com/deislabs/krustlet){:target="_blank"}
+- [Kubernetes](https://kubernetes.io/){:target="_blank"}
+- [Open Container Initiative](https://opencontainers.org/){:target="_blank"}
+- [WebAssembly](https://webassembly.org/){:target="_blank"}
+- [WASI](https://wasi.dev/){:target="_blank"}
+- [Wasmtime](https://wasmtime.dev/){:target="_blank"}
+- [waSCC](https://wascc.dev/){:target="_blank"}
+- [WebAssembly meets Kubernetes with Krustlet](https://cloudblogs.microsoft.com/opensource/2020/04/07/announcing-krustlet-kubernetes-rust-kubelet-webassembly-wasm/){:target="_blank"}
+- [Introducing Krustlet, the WebAssembly Kubelet](https://deislabs.io/posts/introducing-krustlet/){:target="_blank"}
+- [Kubernetes: A Rusty Friendship](https://deislabs.io/posts/kubernetes-a-rusty-friendship/){:target="_blank"}
+- [The Safety Boat: Kubernetes and Rust](https://msrc-blog.microsoft.com/2020/04/29/the-safety-boat-kubernetes-and-rust/){:target="_blank"}
+- [A Heaping Helping of Stacks](https://deislabs.io/posts/a-heaping-helping-of-stacks/){:target="_blank"}
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Jeremy Jung](https://www.softwaresessions.com)
+Audio Editing: [Jeremy Jung](https://www.softwaresessions.com){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
 Show Notes: Jeremy Jung 
 
 Hosts: Jeremy Jung
 
-Guests: [Taylor Thomas](https://twitter.com/_oftaylor)
+Guests: [Taylor Thomas](https://twitter.com/_oftaylor){:target="_blank"}

--- a/_episodes/031-rust-1.46-1.47.md
+++ b/_episodes/031-rust-1.46-1.47.md
@@ -15,33 +15,33 @@ Jon and Ben take a look at the features of Rust 1.46 and 1.47.
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
-#### [@01:55] - [Rust 1.46](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html)
+#### [@01:55] - [Rust 1.46](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html){:target="_blank"}
 
- - [@01:55] - [`const fn` improvements](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html#const-fn-improvements)
- - [@08:38] - [The `track_caller` attribute](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html#track_caller)
- - [@11:51] - [Minor changes](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1460-2020-08-27)
-     - [1.46 pre-release testing](https://blog.rust-lang.org/inside-rust/2020/08/24/1.46.0-prerelease.html)
+ - [@01:55] - [`const fn` improvements](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html#const-fn-improvements){:target="_blank"}
+ - [@08:38] - [The `track_caller` attribute](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html#track_caller){:target="_blank"}
+ - [@11:51] - [Minor changes](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1460-2020-08-27){:target="_blank"}
+     - [1.46 pre-release testing](https://blog.rust-lang.org/inside-rust/2020/08/24/1.46.0-prerelease.html){:target="_blank"}
 
-#### [@21:46] - [Rust 1.47](https://blog.rust-lang.org/2020/10/08/Rust-1.47.html)
+#### [@21:46] - [Rust 1.47](https://blog.rust-lang.org/2020/10/08/Rust-1.47.html){:target="_blank"}
 
- - [@21:46] - [Traits on larger arrays](https://blog.rust-lang.org/2020/10/08/Rust-1.47.html#traits-on-larger-arrays)
-     - [Tracking Issue for `min_const_generics`](https://github.com/rust-lang/rust/issues/74878)
- - [@29:14] - [Shorter backtraces](https://blog.rust-lang.org/2020/10/08/Rust-1.47.html#shorter-backtraces)
- - [@30:26] - [LLVM 11](https://blog.rust-lang.org/2020/10/08/Rust-1.47.html#llvm-11)
- - [@32:07] - [Control Flow Guard on Windows](https://blog.rust-lang.org/2020/10/08/Rust-1.47.html#control-flow-guard-on-windows)
- - [@34:28] - [Library changes](https://blog.rust-lang.org/2020/10/08/Rust-1.47.html#library-changes)
-     - [The Tau Manifesto](https://tauday.com/tau-manifesto)
- - [@40:04] - [Minor changes](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1470-2020-10-08)
-     - [SemVer Compatibility Guide](https://doc.rust-lang.org/cargo/reference/semver.html)
-     - [Announcing the Error Handling Project Group](https://blog.rust-lang.org/inside-rust/2020/09/18/error-handling-wg-announcement.html)
-     - [Announcing the Portable SIMD Project Group](https://blog.rust-lang.org/inside-rust/2020/09/29/Portable-SIMD-PG.html)
+ - [@21:46] - [Traits on larger arrays](https://blog.rust-lang.org/2020/10/08/Rust-1.47.html#traits-on-larger-arrays){:target="_blank"}
+     - [Tracking Issue for `min_const_generics`](https://github.com/rust-lang/rust/issues/74878){:target="_blank"}
+ - [@29:14] - [Shorter backtraces](https://blog.rust-lang.org/2020/10/08/Rust-1.47.html#shorter-backtraces){:target="_blank"}
+ - [@30:26] - [LLVM 11](https://blog.rust-lang.org/2020/10/08/Rust-1.47.html#llvm-11){:target="_blank"}
+ - [@32:07] - [Control Flow Guard on Windows](https://blog.rust-lang.org/2020/10/08/Rust-1.47.html#control-flow-guard-on-windows){:target="_blank"}
+ - [@34:28] - [Library changes](https://blog.rust-lang.org/2020/10/08/Rust-1.47.html#library-changes){:target="_blank"}
+     - [The Tau Manifesto](https://tauday.com/tau-manifesto){:target="_blank"}
+ - [@40:04] - [Minor changes](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1470-2020-10-08){:target="_blank"}
+     - [SemVer Compatibility Guide](https://doc.rust-lang.org/cargo/reference/semver.html){:target="_blank"}
+     - [Announcing the Error Handling Project Group](https://blog.rust-lang.org/inside-rust/2020/09/18/error-handling-wg-announcement.html){:target="_blank"}
+     - [Announcing the Portable SIMD Project Group](https://blog.rust-lang.org/inside-rust/2020/09/29/Portable-SIMD-PG.html){:target="_blank"}
 
 <!--
 In this section, leave timestamped notes of the form:
@@ -54,12 +54,12 @@ In this section, leave timestamped notes of the form:
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Cole](https://twitch.tv/refactorordie)
+Audio Editing: [Cole](https://twitch.tv/refactorordie){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie){:target="_blank"}
 
-Hosts: [Jon Gjengset](https://twitter.com/jonhoo/) and [Ben Striegel](https://twitter.com/bstrie)
+Hosts: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"} and [Ben Striegel](https://twitter.com/bstrie){:target="_blank"}

--- a/_episodes/032-rust-1.48-1.49.md
+++ b/_episodes/032-rust-1.48-1.49.md
@@ -22,34 +22,34 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
-#### [@01:10] - [Rust 1.48](https://blog.rust-lang.org/2020/11/19/Rust-1.48.html)
+#### [@01:10] - [Rust 1.48](https://blog.rust-lang.org/2020/11/19/Rust-1.48.html){:target="_blank"}
 
- - [@01:10] - [Easier linking in Rustdoc](https://blog.rust-lang.org/2020/11/19/Rust-1.48.html#easier-linking-in-rustdoc)
- - [@03:57] - [Adding search aliases in Rustdoc](https://blog.rust-lang.org/2020/11/19/Rust-1.48.html#adding-search-aliases)
- - [@07:03] - [Implement `TryFrom<Vec<T>>` for fixed-length arrays](https://blog.rust-lang.org/2020/11/19/Rust-1.48.html#library-changes)
-     - [`slice::as_chunks`](https://doc.rust-lang.org/std/primitive.slice.html#method.as_chunks)
- - [@10:51] - [`future::ready` and `future::pending`](https://doc.rust-lang.org/std/future/index.html#functions)
+ - [@01:10] - [Easier linking in Rustdoc](https://blog.rust-lang.org/2020/11/19/Rust-1.48.html#easier-linking-in-rustdoc){:target="_blank"}
+ - [@03:57] - [Adding search aliases in Rustdoc](https://blog.rust-lang.org/2020/11/19/Rust-1.48.html#adding-search-aliases){:target="_blank"}
+ - [@07:03] - [Implement `TryFrom<Vec<T>>` for fixed-length arrays](https://blog.rust-lang.org/2020/11/19/Rust-1.48.html#library-changes){:target="_blank"}
+     - [`slice::as_chunks`](https://doc.rust-lang.org/std/primitive.slice.html#method.as_chunks){:target="_blank"}
+ - [@10:51] - [`future::ready` and `future::pending`](https://doc.rust-lang.org/std/future/index.html#functions){:target="_blank"}
  - [@15:21] - More stdlib APIs made `const`
- - [@18:05] - [`mem::uninitialized` will now panic if any inner types inside a struct or enum disallow zero-initialization](https://github.com/rust-lang/rust/pull/71274/)
- - [@20:18] - [When trait bounds on associated types or opaque types are ambiguous, the compiler no longer makes an arbitrary choice on which bound to use](https://github.com/rust-lang/rust/issues/54121/)
+ - [@18:05] - [`mem::uninitialized` will now panic if any inner types inside a struct or enum disallow zero-initialization](https://github.com/rust-lang/rust/pull/71274/){:target="_blank"}
+ - [@20:18] - [When trait bounds on associated types or opaque types are ambiguous, the compiler no longer makes an arbitrary choice on which bound to use](https://github.com/rust-lang/rust/issues/54121/){:target="_blank"}
 
-#### [@24:20] - [Rust 1.49](https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html)
+#### [@24:20] - [Rust 1.49](https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html){:target="_blank"}
 
- - [@24:20] - [64-bit ARM Linux reaches Tier 1](https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html#64-bit-arm-linux-reaches-tier-1)
- - [@30:20] - [Test framework captures output in threads](https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html#test-framework-captures-output-in-threads)
- - [@33:36] - [Library changes](https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html#library-changes)
-     - [`poll::is_ready` and `poll::is_pending` made `const`](https://doc.rust-lang.org/stable/std/task/enum.Poll.html#method.is_ready)
- - [@34:36] - [You can now bind by reference and by move in patterns](https://github.com/rust-lang/rust/pull/76119)
- - [@38:09] - [Unions can now implement `Drop`, and you can now have a field in a union with `ManuallyDrop<T>`](https://github.com/rust-lang/rust/pull/77547)
+ - [@24:20] - [64-bit ARM Linux reaches Tier 1](https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html#64-bit-arm-linux-reaches-tier-1){:target="_blank"}
+ - [@30:20] - [Test framework captures output in threads](https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html#test-framework-captures-output-in-threads){:target="_blank"}
+ - [@33:36] - [Library changes](https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html#library-changes){:target="_blank"}
+     - [`poll::is_ready` and `poll::is_pending` made `const`](https://doc.rust-lang.org/stable/std/task/enum.Poll.html#method.is_ready){:target="_blank"}
+ - [@34:36] - [You can now bind by reference and by move in patterns](https://github.com/rust-lang/rust/pull/76119){:target="_blank"}
+ - [@38:09] - [Unions can now implement `Drop`, and you can now have a field in a union with `ManuallyDrop<T>`](https://github.com/rust-lang/rust/pull/77547){:target="_blank"}
 
-#### [@42:00] - [Rust Survey 2020 Results](https://blog.rust-lang.org/2020/12/16/rust-survey-2020.html)
+#### [@42:00] - [Rust Survey 2020 Results](https://blog.rust-lang.org/2020/12/16/rust-survey-2020.html){:target="_blank"}
 
 <!--
 In this section, leave timestamped notes of the form:
@@ -62,12 +62,12 @@ In this section, leave timestamped notes of the form:
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [T.J. Telan](https://tjtelan.com)
+Audio Editing: [T.J. Telan](https://tjtelan.com){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie){:target="_blank"}
 
 Hosts: Jon Gjengset and Ben Striegel

--- a/_episodes/033-rust-1.50-1.51.md
+++ b/_episodes/033-rust-1.50-1.51.md
@@ -22,72 +22,72 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
-#### [@01:47] - [Rust 1.50](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html)
+#### [@01:47] - [Rust 1.50](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html){:target="_blank"}
 
- - [@03:02] - [Const Generic Array Indexing](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html#const-generic-array-indexing)
- - [@04:30] - [Const Value Repetition for Arrays](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html#const-value-repetition-for-arrays)
-    - [Accidental Stabilization](https://github.com/rust-lang/rust/issues/49147#issuecomment-726796665)
- - [@07:15] - [Safe Assignment to ManuallyDrop in Unions](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html#safe-assignments-to-manuallydropt-union-fields)
- - [@09:40] - [Niche for File on UNIX](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html#a-niche-for-file-on-unix-platforms)
-    - [Niches for Non-Empty Variants](https://github.com/rust-lang/rust/issues/46213)
-    - [Using Padding for Niches](https://github.com/rust-lang/rust/issues/70230)
- - [@14:39] - [Library Changes](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html#library-changes)
-    - [Mara Bos on the journey to `bool::then`](https://twitter.com/m_ou_se/status/1359941126925537281)
-    - [`bool::then` PR](https://github.com/rust-lang/rfcs/pull/2757)
-    - [The Clamp RFC](https://rust-lang.github.io/rfcs/1961-clamp.html)
+ - [@03:02] - [Const Generic Array Indexing](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html#const-generic-array-indexing){:target="_blank"}
+ - [@04:30] - [Const Value Repetition for Arrays](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html#const-value-repetition-for-arrays){:target="_blank"}
+    - [Accidental Stabilization](https://github.com/rust-lang/rust/issues/49147#issuecomment-726796665){:target="_blank"}
+ - [@07:15] - [Safe Assignment to ManuallyDrop in Unions](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html#safe-assignments-to-manuallydropt-union-fields){:target="_blank"}
+ - [@09:40] - [Niche for File on UNIX](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html#a-niche-for-file-on-unix-platforms){:target="_blank"}
+    - [Niches for Non-Empty Variants](https://github.com/rust-lang/rust/issues/46213){:target="_blank"}
+    - [Using Padding for Niches](https://github.com/rust-lang/rust/issues/70230){:target="_blank"}
+ - [@14:39] - [Library Changes](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html#library-changes){:target="_blank"}
+    - [Mara Bos on the journey to `bool::then`](https://twitter.com/m_ou_se/status/1359941126925537281){:target="_blank"}
+    - [`bool::then` PR](https://github.com/rust-lang/rfcs/pull/2757){:target="_blank"}
+    - [The Clamp RFC](https://rust-lang.github.io/rfcs/1961-clamp.html){:target="_blank"}
  - [@20:27] - Changelog Deep-Dive
-    - [Rust Changelog](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1500-2021-02-11)
-    - [Cargo Changelog](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-150-2021-02-11)
-    - [`compare_and_swap` deprecation](https://github.com/rust-lang/rust/pull/79261)
-    - [Deterministic `.crate` files](https://github.com/rust-lang/cargo/pull/8864)
+    - [Rust Changelog](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1500-2021-02-11){:target="_blank"}
+    - [Cargo Changelog](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-150-2021-02-11){:target="_blank"}
+    - [`compare_and_swap` deprecation](https://github.com/rust-lang/rust/pull/79261){:target="_blank"}
+    - [Deterministic `.crate` files](https://github.com/rust-lang/cargo/pull/8864){:target="_blank"}
 
-#### [@25:11] - [Rust 1.51](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html)
+#### [@25:11] - [Rust 1.51](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html){:target="_blank"}
 
- - [@25:24] - [Const Generics MVP](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#const-generics-mvp)
-    - [What Was and Wasn't Stabilized](https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta.html)
- - [@30:00] - [`array::IntoIter` stabilization](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#arrayintoiter-stabilisation)
-    - [Implementing `IntoIterator` for `[T; N]`](https://github.com/rust-lang/rust/pull/65819)
- - [@37:53] - [Cargo's New Feature Resolver](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#cargos-new-feature-resolver)
-    - [Resolver v2 RFC](https://rust-lang.github.io/rfcs/2957-cargo-features2.html)
-    - [Resolver v2 in Cargo Book](https://doc.rust-lang.org/nightly/cargo/reference/features.html#feature-resolver-version-2)
-    - [Issues Solved by New Resolver](https://github.com/rust-lang/cargo/pull/8997)
- - [@45:26] - [Splitting Debug Information](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#splitting-debug-information)
-    - [Why This Was Complicated](https://github.com/rust-lang/rust/issues/79361)
-    - [`split-debuginfo` option](https://doc.rust-lang.org/nightly/rustc/codegen-options/index.html#split-debuginfo)
- - [@51:34] - [Stabilized APIs](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#stabilized-apis)
+ - [@25:24] - [Const Generics MVP](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#const-generics-mvp){:target="_blank"}
+    - [What Was and Wasn't Stabilized](https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta.html){:target="_blank"}
+ - [@30:00] - [`array::IntoIter` stabilization](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#arrayintoiter-stabilisation){:target="_blank"}
+    - [Implementing `IntoIterator` for `[T; N]`](https://github.com/rust-lang/rust/pull/65819){:target="_blank"}
+ - [@37:53] - [Cargo's New Feature Resolver](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#cargos-new-feature-resolver){:target="_blank"}
+    - [Resolver v2 RFC](https://rust-lang.github.io/rfcs/2957-cargo-features2.html){:target="_blank"}
+    - [Resolver v2 in Cargo Book](https://doc.rust-lang.org/nightly/cargo/reference/features.html#feature-resolver-version-2){:target="_blank"}
+    - [Issues Solved by New Resolver](https://github.com/rust-lang/cargo/pull/8997){:target="_blank"}
+ - [@45:26] - [Splitting Debug Information](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#splitting-debug-information){:target="_blank"}
+    - [Why This Was Complicated](https://github.com/rust-lang/rust/issues/79361){:target="_blank"}
+    - [`split-debuginfo` option](https://doc.rust-lang.org/nightly/rustc/codegen-options/index.html#split-debuginfo){:target="_blank"}
+ - [@51:34] - [Stabilized APIs](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#stabilized-apis){:target="_blank"}
     - [`offset_of!` is (was) Unsound](https://github.com/Gilnaa/memoffset/issues/24)
-    - [`ptr::addr_of!`](https://doc.rust-lang.org/stable/std/ptr/macro.addr_of.html)
-    - [Raw pointer creation RFC](https://rust-lang.github.io/rfcs/2582-raw-reference-mir-operator.html)
-    - [Ergonomic string interpolation](https://rust-lang.github.io/rfcs/2795-format-args-implicit-identifiers.html)
-    - [Unifying `panic!`](https://rust-lang.github.io/rfcs/3007-panic-plan.html)
-    - [Manual vTable for Wakers](https://doc.rust-lang.org/stable/std/task/struct.RawWakerVTable.html)
+{:target="_blank"}    - [`ptr::addr_of!`](https://doc.rust-lang.org/stable/std/ptr/macro.addr_of.html){:target="_blank"}
+    - [Raw pointer creation RFC](https://rust-lang.github.io/rfcs/2582-raw-reference-mir-operator.html){:target="_blank"}
+    - [Ergonomic string interpolation](https://rust-lang.github.io/rfcs/2795-format-args-implicit-identifiers.html){:target="_blank"}
+    - [Unifying `panic!`](https://rust-lang.github.io/rfcs/3007-panic-plan.html){:target="_blank"}
+    - [Manual vTable for Wakers](https://doc.rust-lang.org/stable/std/task/struct.RawWakerVTable.html){:target="_blank"}
  - [@1:10:30] - Changelog Deep-Dive
-    - [Rust Changelog](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1510-2021-03-25)
-    - [Cargo Changelog](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-151-2021-03-25)
-    - [Documenting Nested Derefs](https://github.com/rust-lang/rust/pull/80653)
-    - [Smarter `target-cpu=native`](https://github.com/rust-lang/rust/pull/80749)
+    - [Rust Changelog](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1510-2021-03-25){:target="_blank"}
+    - [Cargo Changelog](https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-151-2021-03-25){:target="_blank"}
+    - [Documenting Nested Derefs](https://github.com/rust-lang/rust/pull/80653){:target="_blank"}
+    - [Smarter `target-cpu=native`](https://github.com/rust-lang/rust/pull/80749){:target="_blank"}
 
-#### [@1:14:45] - [Rust Async Vision Doc](https://blog.rust-lang.org/2021/03/18/async-vision-doc.html)
+#### [@1:14:45] - [Rust Async Vision Doc](https://blog.rust-lang.org/2021/03/18/async-vision-doc.html){:target="_blank"}
 
- - [Async Foundations Working Group](https://rust-lang.github.io/wg-async-foundations/welcome.html)
+ - [Async Foundations Working Group](https://rust-lang.github.io/wg-async-foundations/welcome.html){:target="_blank"}
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Aerocity](https://twitter.com/AerocityMusic)
+Audio Editing: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Jon Gjengset](https://twitter.com/jonhoo/)
+Show Notes: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
 Hosts: Jon Gjengset and Ben Striegel
 
-Transcript: [Eric Seppanen](https://github.com/ericseppanen)
+Transcript: [Eric Seppanen](https://github.com/ericseppanen){:target="_blank"}

--- a/_episodes/034-rust-1.52-1.53.md
+++ b/_episodes/034-rust-1.52-1.53.md
@@ -22,57 +22,57 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
-#### [@01:31] - [Rust 1.52](https://blog.rust-lang.org/2021/05/06/Rust-1.52.0.html)
+#### [@01:31] - [Rust 1.52](https://blog.rust-lang.org/2021/05/06/Rust-1.52.0.html){:target="_blank"}
 
- - [@01:31] - [Stabilized APIs](https://blog.rust-lang.org/2021/05/06/Rust-1.52.0.html#stabilized-apis)
- - [@04:28] - [All integer division and remainder APIs made const](https://github.com/rust-lang/rust/pull/80962)
- - [@07:45] - [Rust 1.52.1 and incremental compilation](https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html)
- - [@11:30] - [LLVM 12](https://github.com/rust-lang/rust/pull/81451)
-     - [Disable "mutable noalias"](https://github.com/rust-lang/rust/issues/84958)
-     - [Bringing Stack Clash Protection to Clang/x86, the Open Source Way](https://blog.llvm.org/posts/2021-01-05-stack-clash-protection/)
- - [@16:15] - [`unsafe_op_in_unsafe_fn` lint](https://github.com/rust-lang/rust/pull/79208)
+ - [@01:31] - [Stabilized APIs](https://blog.rust-lang.org/2021/05/06/Rust-1.52.0.html#stabilized-apis){:target="_blank"}
+ - [@04:28] - [All integer division and remainder APIs made const](https://github.com/rust-lang/rust/pull/80962){:target="_blank"}
+ - [@07:45] - [Rust 1.52.1 and incremental compilation](https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html){:target="_blank"}
+ - [@11:30] - [LLVM 12](https://github.com/rust-lang/rust/pull/81451){:target="_blank"}
+     - [Disable "mutable noalias"](https://github.com/rust-lang/rust/issues/84958){:target="_blank"}
+     - [Bringing Stack Clash Protection to Clang/x86, the Open Source Way](https://blog.llvm.org/posts/2021-01-05-stack-clash-protection/){:target="_blank"}
+ - [@16:15] - [`unsafe_op_in_unsafe_fn` lint](https://github.com/rust-lang/rust/pull/79208){:target="_blank"}
 
-#### [@23:03] - [Rust 1.53](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html)
+#### [@23:03] - [Rust 1.53](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html){:target="_blank"}
 
- - [@23:03] - [`IntoIterator` for arrays](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#intoiterator-for-arrays)
- - [@26:45] - [Unicode identifiers](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#unicode-identifiers)
- - [@29:37] - [Or patterns](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#or-patterns)
- - [@31:05] - [Stabilized APIs](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#stabilized-apis)
-     - [`BITS` associated const on numeric primitives](https://github.com/rust-lang/rust/issues/81654)
+ - [@23:03] - [`IntoIterator` for arrays](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#intoiterator-for-arrays){:target="_blank"}
+ - [@26:45] - [Unicode identifiers](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#unicode-identifiers){:target="_blank"}
+ - [@29:37] - [Or patterns](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#or-patterns){:target="_blank"}
+ - [@31:05] - [Stabilized APIs](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#stabilized-apis){:target="_blank"}
+     - [`BITS` associated const on numeric primitives](https://github.com/rust-lang/rust/issues/81654){:target="_blank"}
  - [@36:36] - [`{f32, f64}::from_str` now parse and print special values (NaN, -0) according to IEEE RFC 754.](https://github.com/rust-lang/rust/pull/78618)
- - [@38:05] - [`{f32, f64}::is_subnormal`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.is_subnormal)
+{:target="_blank"} - [@38:05] - [`{f32, f64}::is_subnormal`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.is_subnormal){:target="_blank"}
  - [@41:11] - Cargo changes
-     - [RFC: Make the authors field optional](https://rust-lang.github.io/rfcs/3052-optional-authors-field.html)
+     - [RFC: Make the authors field optional](https://rust-lang.github.io/rfcs/3052-optional-authors-field.html){:target="_blank"}
 
-#### [@43:52] - [Rust 2021 Edition Preview](https://blog.rust-lang.org/2021/05/11/edition-2021.html)
+#### [@43:52] - [Rust 2021 Edition Preview](https://blog.rust-lang.org/2021/05/11/edition-2021.html){:target="_blank"}
 
  - [@43:52] - What is an edition?
- - [@47:33] - [Additions to the prelude](https://blog.rust-lang.org/2021/05/11/edition-2021.html#additions-to-the-prelude)
- - [@50:54] - [Default Cargo feature resolver](https://blog.rust-lang.org/2021/05/11/edition-2021.html#default-cargo-feature-resolver)
- - [@51:49] - [`IntoIterator` for arrays](https://blog.rust-lang.org/2021/05/11/edition-2021.html#intoiterator-for-arrays)
- - [@53:09] - [Disjoint capture in closures](https://blog.rust-lang.org/2021/05/11/edition-2021.html#disjoint-capture-in-closures)
- - [@54:35] - [Panic macro consistency](https://blog.rust-lang.org/2021/05/11/edition-2021.html#panic-macro-consistency)
- - [@56:00] - [Reserving syntax](https://blog.rust-lang.org/2021/05/11/edition-2021.html#reserving-syntax)
- - [@1:01:38] - [Or patterns in macro_rules](https://blog.rust-lang.org/2021/05/11/edition-2021.html#or-patterns-in-macro_rules)
- - [@1:03:16] - [Promoting two warnings to hard errors](https://blog.rust-lang.org/2021/05/11/edition-2021.html#promoting-two-warnings-to-hard-errors)
+ - [@47:33] - [Additions to the prelude](https://blog.rust-lang.org/2021/05/11/edition-2021.html#additions-to-the-prelude){:target="_blank"}
+ - [@50:54] - [Default Cargo feature resolver](https://blog.rust-lang.org/2021/05/11/edition-2021.html#default-cargo-feature-resolver){:target="_blank"}
+ - [@51:49] - [`IntoIterator` for arrays](https://blog.rust-lang.org/2021/05/11/edition-2021.html#intoiterator-for-arrays){:target="_blank"}
+ - [@53:09] - [Disjoint capture in closures](https://blog.rust-lang.org/2021/05/11/edition-2021.html#disjoint-capture-in-closures){:target="_blank"}
+ - [@54:35] - [Panic macro consistency](https://blog.rust-lang.org/2021/05/11/edition-2021.html#panic-macro-consistency){:target="_blank"}
+ - [@56:00] - [Reserving syntax](https://blog.rust-lang.org/2021/05/11/edition-2021.html#reserving-syntax){:target="_blank"}
+ - [@1:01:38] - [Or patterns in macro_rules](https://blog.rust-lang.org/2021/05/11/edition-2021.html#or-patterns-in-macro_rules){:target="_blank"}
+ - [@1:03:16] - [Promoting two warnings to hard errors](https://blog.rust-lang.org/2021/05/11/edition-2021.html#promoting-two-warnings-to-hard-errors){:target="_blank"}
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Jeremy Jung](https://www.softwaresessions.com)
+Audio Editing: [Jeremy Jung](https://www.softwaresessions.com){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Ben Striegel](https://twitter.com/bstrie/)
+Show Notes: [Ben Striegel](https://twitter.com/bstrie/){:target="_blank"}
 
 Hosts: Jon Gjengset and Ben Striegel
 
-Transcript: [Eric Seppanen](https://github.com/ericseppanen)
+Transcript: [Eric Seppanen](https://github.com/ericseppanen){:target="_blank"}

--- a/_episodes/035-daniel-stenberg.md
+++ b/_episodes/035-daniel-stenberg.md
@@ -8,7 +8,7 @@ length: "53290745"
 ---
 First time guest host, Allen Wyma talks with Daniel, the original author of cURL, about using Rust in cURL.
 
-- [cURL](https://curl.se/) is a command line tool and library for transferring data with URLs.
+- [cURL](https://curl.se/){:target="_blank"} is a command line tool and library for transferring data with URLs.
 - cURL, and its data transfer core, libcurl are both written in C, which is known to be not memory safe. 
 - While it is almost impossibe to rewrite it into another language, offering a third-party library written in Rust could take a further step forward.
 
@@ -16,10 +16,10 @@ First time guest host, Allen Wyma talks with Daniel, the original author of cURL
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Highlights
 
@@ -30,12 +30,12 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 - What benefits does Rust bring to cURL?
 
 ## Resources 
- - [Curl](https://curl.se/)
- - [Daniel's Blog](https://daniel.haxx.se/blog/2021/08/09/nocais-apology/)
- - [Project Gemini](https://gemini.circumlunar.space/)
+ - [Curl](https://curl.se/){:target="_blank"}
+ - [Daniel's Blog](https://daniel.haxx.se/blog/2021/08/09/nocais-apology/){:target="_blank"}
+ - [Project Gemini](https://gemini.circumlunar.space/){:target="_blank"}
 
 ## Timestamps 
-- [@05:10] - [cURL 7.78.0](https://curl.se/download.html)
+- [@05:10] - [cURL 7.78.0](https://curl.se/download.html){:target="_blank"}
 - [@07:44] - Implementing Protocol
 - [@09:25] - HTTP/3
 - [@13:30] - Architecture of cURL & libcurl
@@ -50,12 +50,12 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/036-luca-palmieri.md
+++ b/_episodes/036-luca-palmieri.md
@@ -6,43 +6,43 @@ duration: "1:07:42"
 length: "65103280"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with [Luca Palmieri](https://twitter.com/algo_luca), a principal engineer at [TrueLayer](https://truelayer.com/), about his book called ["Zero To Production in Rust"](https://www.zero2prod.com/).
+Allen Wyma talks with [Luca Palmieri](https://twitter.com/algo_luca){:target="_blank"}, a principal engineer at [TrueLayer](https://truelayer.com/){:target="_blank"}, about his book called ["Zero To Production in Rust"](https://www.zero2prod.com/){:target="_blank"}.
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
 - [@02:30] - Book ideas
 - [@13:20] - Reasons for using Rust in production
-- [@10:34] - [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/08_ecosystem/00_chapter.html)
-- [@16:45] - [Actix Web](https://github.com/actix/actix-web)
+- [@10:34] - [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/08_ecosystem/00_chapter.html){:target="_blank"}
+- [@16:45] - [Actix Web](https://github.com/actix/actix-web){:target="_blank"}
 - [@32:21] - Challenges in using Rust as backend language 
-- [@36:30] - What is [krustlet](https://krustlet.dev/)?
+- [@36:30] - What is [krustlet](https://krustlet.dev/){:target="_blank"}?
 - [@46:35] - How is the process of writing the book 
-- [@54:50] - [Rust edition 2021](https://doc.rust-lang.org/edition-guide/rust-2021/index.html)
+- [@54:50] - [Rust edition 2021](https://doc.rust-lang.org/edition-guide/rust-2021/index.html){:target="_blank"}
 - [@57:40] - Rust's community
-- [@59:37] - [Rust for Rustaceans](https://nostarch.com/rust-rustaceans)
-- [@1:00:26] - [Rust in Action](https://www.manning.com/books/rust-in-action)
+- [@59:37] - [Rust for Rustaceans](https://nostarch.com/rust-rustaceans){:target="_blank"}
+- [@1:00:26] - [Rust in Action](https://www.manning.com/books/rust-in-action){:target="_blank"}
 - [@1:01:34] - Tips for beginners
 
 ## Other Resources
-- [Luca's blog](https://lpalmieri.com)
-- [Hexagonal Architecture](https://en.wikipedia.org/wiki/Hexagonal_architecture_(software))
+- [Luca's blog](https://lpalmieri.com){:target="_blank"}
+- [Hexagonal Architecture](https://en.wikipedia.org/wiki/Hexagonal_architecture_(software)){:target="_blank"}
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/037-daniel-mckenna.md
+++ b/_episodes/037-daniel-mckenna.md
@@ -6,47 +6,47 @@ duration: "0:55:49"
 length: "53865895"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with Daniel McKenna, a software enginner, about his code coverage tool for Rust projects, [Tarpaulin](https://github.com/xd009642/tarpaulin).
+Allen Wyma talks with Daniel McKenna, a software enginner, about his code coverage tool for Rust projects, [Tarpaulin](https://github.com/xd009642/tarpaulin){:target="_blank"}.
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
-- [@01:35] - [LLVM](https://llvm.org/) 
-- [@05:50] - [Vectorcast](https://www.vector.com/int/en/products/products-a-z/software/vectorcast/)
-- [@07:00] - [Cargo-kcov](https://github.com/kennytm/cargo-kcov)
-- [@07:38] - [Gdb](https://www.gnu.org/software/gdb/)
-- [@07:47] - [ptrace.2](https://man7.org/linux/man-pages/man2/ptrace.2.html)
-- [@14:40] - [Arduino](https://www.arduino.cc/)
-- [@15:47] - [Probe-rs](https://github.com/probe-rs/probe-rs)
-- [@22:42] - [Tarpaulin Crater (tater)](https://github.com/xd009642/tater)
-- [@23:34] - [Tarpaulin-viewer](https://github.com/xd009642/tarpaulin-viewer)
-- [@27:51] - [ImGui](https://github.com/imgui-rs/imgui-rs)
-- [@31:00] - [Ndarray](https://github.com/rust-ndarray/ndarray)
+- [@01:35] - [LLVM](https://llvm.org/){:target="_blank"} 
+- [@05:50] - [Vectorcast](https://www.vector.com/int/en/products/products-a-z/software/vectorcast/){:target="_blank"}
+- [@07:00] - [Cargo-kcov](https://github.com/kennytm/cargo-kcov){:target="_blank"}
+- [@07:38] - [Gdb](https://www.gnu.org/software/gdb/){:target="_blank"}
+- [@07:47] - [ptrace.2](https://man7.org/linux/man-pages/man2/ptrace.2.html){:target="_blank"}
+- [@14:40] - [Arduino](https://www.arduino.cc/){:target="_blank"}
+- [@15:47] - [Probe-rs](https://github.com/probe-rs/probe-rs){:target="_blank"}
+- [@22:42] - [Tarpaulin Crater (tater)](https://github.com/xd009642/tater){:target="_blank"}
+- [@23:34] - [Tarpaulin-viewer](https://github.com/xd009642/tarpaulin-viewer){:target="_blank"}
+- [@27:51] - [ImGui](https://github.com/imgui-rs/imgui-rs){:target="_blank"}
+- [@31:00] - [Ndarray](https://github.com/rust-ndarray/ndarray){:target="_blank"}
 - [@32:09] - Is rust a competitor of Julia and Python in terms of machine learning?
 - [@36:10] - When did Daniel get into programming? 
 - [@49:20] - Tips for beginners 
-- [@53:53] - [FiraCode](https://github.com/tonsky/FiraCode)
+- [@53:53] - [FiraCode](https://github.com/tonsky/FiraCode){:target="_blank"}
 
 ## Other Resources
-- [Writing a Debugger](http://system.joekain.com/debugger/)
-- [Writing a Linux Debugger Setup](https://blog.tartanllama.xyz/writing-a-linux-debugger-setup/)
-- [Awesome Rust Mentors](https://rustbeginners.github.io/awesome-rust-mentors/)
+- [Writing a Debugger](http://system.joekain.com/debugger/){:target="_blank"}
+- [Writing a Linux Debugger Setup](https://blog.tartanllama.xyz/writing-a-linux-debugger-setup/){:target="_blank"}
+- [Awesome Rust Mentors](https://rustbeginners.github.io/awesome-rust-mentors/){:target="_blank"}
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/038-jon-gjengset.md
+++ b/_episodes/038-jon-gjengset.md
@@ -6,41 +6,41 @@ duration: "1:21:48"
 length: "79237006"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with Jon Gjengset, a software enginner at [AWS](https://aws.amazon.com/), about his book [Rust for Rustaceans](https://nostarch.com/rust-rustaceans).
+Allen Wyma talks with Jon Gjengset, a software enginner at [AWS](https://aws.amazon.com/){:target="_blank"}, about his book [Rust for Rustaceans](https://nostarch.com/rust-rustaceans){:target="_blank"}.
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
 
-- [@11:24] - [Noria](https://github.com/mit-pdos/noria)
-- [@13:00] - [Jon's Youtube Channel](https://www.youtube.com/c/JonGjengset)
-- [@21:53] - [Crust of Rust](https://www.youtube.com/watch?v=rAl-9HwD858&list=PLqbS7AVVErFiWDOAVrPt7aYmnuuOLYvOa)
+- [@11:24] - [Noria](https://github.com/mit-pdos/noria){:target="_blank"}
+- [@13:00] - [Jon's Youtube Channel](https://www.youtube.com/c/JonGjengset){:target="_blank"}
+- [@21:53] - [Crust of Rust](https://www.youtube.com/watch?v=rAl-9HwD858&list=PLqbS7AVVErFiWDOAVrPt7aYmnuuOLYvOa){:target="_blank"}
 - [@25:13] - What does it mean to be a Rustacean?
-   - [Niko Matsakis' Rustacean Principles](https://github.com/nikomatsakis/rustacean-principles)
+   - [Niko Matsakis' Rustacean Principles](https://github.com/nikomatsakis/rustacean-principles){:target="_blank"}
 - [@27:23] - What does intermediate content mean?
-- [@30:03] - [Chapter on memory in Rust](https://nostarch.com/download/samples/RustforRustaceans_Ch2new.pdf)
+- [@30:03] - [Chapter on memory in Rust](https://nostarch.com/download/samples/RustforRustaceans_Ch2new.pdf){:target="_blank"}
 - [@41:21] - Does Rust prevent bugs?
 - [@58:20] - The Linux kernel and memory allocation failures
 - [@1:05:43] - Feature flag discoverability
 - [@1:10:14] - Tips for beginners 
 
 ## Other Resources 
-- [Jon's Fosstodon](https://fosstodon.org/@jonhoo)
+- [Jon's Fosstodon](https://fosstodon.org/@jonhoo){:target="_blank"}
 
 ## Credits
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/039-rust-1.54-1.55.md
+++ b/_episodes/039-rust-1.54-1.55.md
@@ -22,60 +22,60 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
-#### [@00:37] - [Rust 1.54](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html)
+#### [@00:37] - [Rust 1.54](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html){:target="_blank"}
 
- - [@00:55] - [Attributes can invoke function-like macros](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html#attributes-can-invoke-function-like-macros)
-     - [The `doc` attribute](https://doc.rust-lang.org/rustdoc/the-doc-attribute.html)
- - [@04:04] - [wasm32 intrinsics stabilized](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html#wasm32-intrinsics-stabilized)
-     - [`std::intrinsics`](https://doc.rust-lang.org/std/intrinsics/index.html)
-     - [Target families](https://doc.rust-lang.org/reference/conditional-compilation.html#target_family)
- - [@06:59] - [Incremental compilation is re-enabled by default](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html#incremental-compilation-is-re-enabled-by-default)
-     - [Rust 1.52.1 disables incremental compilation](https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html)
-     - [Incremental compilation issues tracking issue](https://github.com/rust-lang/rust/issues/84970)
- - [@08:55] - [Stabilized APIs](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html#stabilized-apis)
+ - [@00:55] - [Attributes can invoke function-like macros](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html#attributes-can-invoke-function-like-macros){:target="_blank"}
+     - [The `doc` attribute](https://doc.rust-lang.org/rustdoc/the-doc-attribute.html){:target="_blank"}
+ - [@04:04] - [wasm32 intrinsics stabilized](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html#wasm32-intrinsics-stabilized){:target="_blank"}
+     - [`std::intrinsics`](https://doc.rust-lang.org/std/intrinsics/index.html){:target="_blank"}
+     - [Target families](https://doc.rust-lang.org/reference/conditional-compilation.html#target_family){:target="_blank"}
+ - [@06:59] - [Incremental compilation is re-enabled by default](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html#incremental-compilation-is-re-enabled-by-default){:target="_blank"}
+     - [Rust 1.52.1 disables incremental compilation](https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html){:target="_blank"}
+     - [Incremental compilation issues tracking issue](https://github.com/rust-lang/rust/issues/84970){:target="_blank"}
+ - [@08:55] - [Stabilized APIs](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html#stabilized-apis){:target="_blank"}
  - [@11:00] - Changelog deep-div
-     - [@11:04] - [`cargo report` and future incompatibility lints](https://github.com/rust-lang/cargo/pull/9438)
-     - [@14:12] - [LLVM mutable noalias is on again](https://github.com/rust-lang/rust/pull/82834)
-     - [@16:24] - [`CARGO_TARGET_TMPDIR`](https://github.com/rust-lang/cargo/pull/9375)
-     - [@17:24] - [Use semver 1.0](https://github.com/rust-lang/cargo/pull/9508)
-         - [Checking semver 1.0 against crates.io](https://github.com/dtolnay/semver/issues/237)
+     - [@11:04] - [`cargo report` and future incompatibility lints](https://github.com/rust-lang/cargo/pull/9438){:target="_blank"}
+     - [@14:12] - [LLVM mutable noalias is on again](https://github.com/rust-lang/rust/pull/82834){:target="_blank"}
+     - [@16:24] - [`CARGO_TARGET_TMPDIR`](https://github.com/rust-lang/cargo/pull/9375){:target="_blank"}
+     - [@17:24] - [Use semver 1.0](https://github.com/rust-lang/cargo/pull/9508){:target="_blank"}
+         - [Checking semver 1.0 against crates.io](https://github.com/dtolnay/semver/issues/237){:target="_blank"}
 
-#### [@19:18] - [Rust 1.55](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html)
+#### [@19:18] - [Rust 1.55](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html){:target="_blank"}
 
- - [@19:26] - [Cargo deduplicates compiler errors](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html#cargo-deduplicates-compiler-errors)
- - [@20:24] - [Faster, more correct float parsing](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html#faster-more-correct-float-parsing)
-     - [The PR](https://github.com/rust-lang/rust/pull/86761)
-     - [Reddit post with details](https://www.reddit.com/r/rust/comments/omelz4/making_rust_float_parsing_fast_libcore_edition/)
- - [@22:20] - [`io::ErrorKind` variants updates](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html#stdioerrorkind-variants-updated)
- - [@28:08] - [Open range patterns added](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html#open-range-patterns-added)
- - [@29:44] - [Stabilized APIs](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html#stabilized-apis)
-     - [@29:44] - [`MaybeUninit`](https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html)
-     - [@32:44] - [`ops::ControlFlow`](https://doc.rust-lang.org/stable/std/ops/enum.ControlFlow.html)
-         - [Try trait (v2) RFC](https://rust-lang.github.io/rfcs/3058-try-trait-v2.html)
-     - [@35:59] - [`string::Drain::as_str`](https://doc.rust-lang.org/stable/std/string/struct.Drain.html#method.as_str)
+ - [@19:26] - [Cargo deduplicates compiler errors](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html#cargo-deduplicates-compiler-errors){:target="_blank"}
+ - [@20:24] - [Faster, more correct float parsing](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html#faster-more-correct-float-parsing){:target="_blank"}
+     - [The PR](https://github.com/rust-lang/rust/pull/86761){:target="_blank"}
+     - [Reddit post with details](https://www.reddit.com/r/rust/comments/omelz4/making_rust_float_parsing_fast_libcore_edition/){:target="_blank"}
+ - [@22:20] - [`io::ErrorKind` variants updates](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html#stdioerrorkind-variants-updated){:target="_blank"}
+ - [@28:08] - [Open range patterns added](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html#open-range-patterns-added){:target="_blank"}
+ - [@29:44] - [Stabilized APIs](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html#stabilized-apis){:target="_blank"}
+     - [@29:44] - [`MaybeUninit`](https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html){:target="_blank"}
+     - [@32:44] - [`ops::ControlFlow`](https://doc.rust-lang.org/stable/std/ops/enum.ControlFlow.html){:target="_blank"}
+         - [Try trait (v2) RFC](https://rust-lang.github.io/rfcs/3058-try-trait-v2.html){:target="_blank"}
+     - [@35:59] - [`string::Drain::as_str`](https://doc.rust-lang.org/stable/std/string/struct.Drain.html#method.as_str){:target="_blank"}
  - [@37:52] - Changelog deep-dive
-     - [@38:08] - [Build scripts informed about rustc configuration](https://doc.rust-lang.org/nightly/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts)
-     - [@38:38] - [`cargo clippy --fix`](https://github.com/rust-lang/rust-clippy/pull/7405)
-     - [@39:10] - [Clippy lint override survey](https://github.com/rust-lang/rust-clippy/issues/7666)
-     - [@40:07] - [`#[doc(hidden)]` on trait implementations](https://github.com/rust-lang/rust/pull/86513)
+     - [@38:08] - [Build scripts informed about rustc configuration](https://doc.rust-lang.org/nightly/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts){:target="_blank"}
+     - [@38:38] - [`cargo clippy --fix`](https://github.com/rust-lang/rust-clippy/pull/7405){:target="_blank"}
+     - [@39:10] - [Clippy lint override survey](https://github.com/rust-lang/rust-clippy/issues/7666){:target="_blank"}
+     - [@40:07] - [`#[doc(hidden)]` on trait implementations](https://github.com/rust-lang/rust/pull/86513){:target="_blank"}
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Jeremy Jung](https://www.softwaresessions.com)
+Audio Editing: [Jeremy Jung](https://www.softwaresessions.com){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Jon Gjengset](https://twitter.com/jonhoo/)
+Show Notes: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
 Hosts: Jon Gjengset and Ben Striegel
 
-Transcript: [Eric Seppanen](https://github.com/ericseppanen)
+Transcript: [Eric Seppanen](https://github.com/ericseppanen){:target="_blank"}

--- a/_episodes/040-louis-pilford.md
+++ b/_episodes/040-louis-pilford.md
@@ -6,41 +6,41 @@ duration: "1:00:07"
 length: "58430610"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with Louis Pilfold, the creator and lead designer of [Gleam](https://gleam.run/). 
+Allen Wyma talks with Louis Pilfold, the creator and lead designer of [Gleam](https://gleam.run/).{:target="_blank"} 
 
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
 
-- [@00:55] - [Louis's Bio](https://twitter.com/louispilfold)
-- [@02:15] - [Erlang](https://www.erlang.org/)
-- [@09:03] - [Rust Project Manager, Cargo](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html)
+- [@00:55] - [Louis's Bio](https://twitter.com/louispilfold){:target="_blank"}
+- [@02:15] - [Erlang](https://www.erlang.org/){:target="_blank"}
+- [@09:03] - [Rust Project Manager, Cargo](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html){:target="_blank"}
 - [@12:15] - Reason of using Rust to implement the compiler 
 - [@19:01] - Why Erlang?
 - [@23:07] - Erlang programming model 
 - [@27:45] - How does Gleam work?
-- [@31:07] - Problems with [TypeScript](https://www.typescriptlang.org/)
-- [@33:38] - What is [Erlang Dialyzer](https://erlang.org/doc/man/dialyzer.html)?
+- [@31:07] - Problems with [TypeScript](https://www.typescriptlang.org/){:target="_blank"}
+- [@33:38] - What is [Erlang Dialyzer](https://erlang.org/doc/man/dialyzer.html)?{:target="_blank"}
 - [@38:06] - Changes to Gleam compiler 
-- [@44:47] - [Gleam v0.17](https://gleam.run/news/gleam-v0.17-released/)
+- [@44:47] - [Gleam v0.17](https://gleam.run/news/gleam-v0.17-released/){:target="_blank"}
 - [@49:45] - Pros and Cons of using Rust as a compiler
 - [@52:30] - Tips and Tricks for beginners 
 
 ## Credits
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/041-carl-lerche.md
+++ b/_episodes/041-carl-lerche.md
@@ -6,44 +6,44 @@ duration: "1:16:07"
 length: "73810256"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with Carl Lerche, a principal engineer at [AWS](https://aws.amazon.com/), also one of the founders of  [Tokio](https://tokio.rs/). 
+Allen Wyma talks with Carl Lerche, a principal engineer at [AWS](https://aws.amazon.com/){:target="_blank"}, also one of the founders of  [Tokio](https://tokio.rs/){:target="_blank"}.
 
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
 
-- [@00:35] - [Carl's Bio](https://twitter.com/carllerche/)
-- [@02:30] - [Apache Cassandra](https://cassandra.apache.org/_/index.html)
-- [@07:45] - [Epoll ](https://man7.org/linux/man-pages/man7/epoll.7.html)
-- [@07:51] - [Kqueue](https://www.freebsd.org/cgi/man.cgi?kqueue)
-- [@07:55] - [I/O Completion Ports](https://docs.microsoft.com/en-us/windows/win32/fileio/i-o-completion-ports)
-- [@14:07] - [Eventual](https://github.com/carllerche/eventual)
-- [@18:55] - [Module pin](https://doc.rust-lang.org/std/pin/index.html)
+- [@00:35] - [Carl's Bio](https://twitter.com/carllerche/){:target="_blank"}
+- [@02:30] - [Apache Cassandra](https://cassandra.apache.org/_/index.html){:target="_blank"}
+- [@07:45] - [Epoll ](https://man7.org/linux/man-pages/man7/epoll.7.html){:target="_blank"}
+- [@07:51] - [Kqueue](https://www.freebsd.org/cgi/man.cgi?kqueue){:target="_blank"}
+- [@07:55] - [I/O Completion Ports](https://docs.microsoft.com/en-us/windows/win32/fileio/i-o-completion-ports){:target="_blank"}
+- [@14:07] - [Eventual](https://github.com/carllerche/eventual){:target="_blank"}
+- [@18:55] - [Module pin](https://doc.rust-lang.org/std/pin/index.html){:target="_blank"}
 - [@28:35] - What do macros expand to?
-- [@30:41] - [Cargo-expand](https://github.com/dtolnay/cargo-expand)
+- [@30:41] - [Cargo-expand](https://github.com/dtolnay/cargo-expand){:target="_blank"}
 - [@42:44] - What's new since Tokio 1.0
-- [@45:02] - [Tokio-console](https://github.com/tokio-rs/console)
+- [@45:02] - [Tokio-console](https://github.com/tokio-rs/console){:target="_blank"}
 - [@01:05:15] - Tokio ecosystem
 
 ## Other Resources
-- [Carl's Github](https://github.com/carllerche/)
-- [Carl's personal blog](https://carllerche.com/)
+- [Carl's Github](https://github.com/carllerche/){:target="_blank"}
+- [Carl's personal blog](https://carllerche.com/){:target="_blank"}
 
 ## Credits
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/042-ben-striegel.md
+++ b/_episodes/042-ben-striegel.md
@@ -6,48 +6,48 @@ duration: "1:32:39"
 length: "89712021"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with [Ben Striegel](https://github.com/bstrie), a member of Rust's official community outreach team, about the history of Rust. 
+Allen Wyma talks with [Ben Striegel](https://github.com/bstrie){:target="_blank"}, a member of Rust's official community outreach team, about the history of Rust.
 
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
 
 - [@1:56] - What got Ben first interested in Rust?
 - [@3:03] - How Ben got involved
 - [@9:36] - Rust 1.0
-- [@16:21] - What does [move](https://doc.rust-lang.org/std/keyword.move.html) mean?
-- [@17:36] - The [Borrow Checker](https://rustc-dev-guide.rust-lang.org/borrow_check.html)
+- [@16:21] - What does [move](https://doc.rust-lang.org/std/keyword.move.html) mean?{:target="_blank"}
+- [@17:36] - The [Borrow Checker](https://rustc-dev-guide.rust-lang.org/borrow_check.html){:target="_blank"}
 - [@20:04] - What language was the Rust compiler first written in?
-- [@25:04] - Choosing [LLVM](https://llvm.org/) over [GCC](https://gcc.gnu.org/)
+- [@25:04] - Choosing [LLVM](https://llvm.org/) over [GCC](https://gcc.gnu.org/){:target="_blank"}
 - [@33:28] - 2 ways to target Windows
-- [@34:39] - [libc](https://crates.io/crates/libc) and [musl](https://www.musl-libc.org/)
+- [@34:39] - [libc](https://crates.io/crates/libc) and [musl](https://www.musl-libc.org/){:target="_blank"}
 - [@36:22] - Rust Editions
 - [@46:46] - Does Rust have a small standard library?
-- [@54:18] - Why [TOML](https://toml.io/en/)? TOML vs [YAML](https://yaml.org/)
-- [@58:53] - ["Tree shaking"](https://webpack.js.org/guides/tree-shaking/) in Rust?
+- [@54:18] - Why [TOML](https://toml.io/en/)? TOML vs [YAML](https://yaml.org/){:target="_blank"}
+- [@58:53] - ["Tree shaking"](https://webpack.js.org/guides/tree-shaking/) in Rust?{:target="_blank"}
 - [@01:00:48] - Who created Cargo?
 - [@01:02:26] - Rust's milestones
-- [@01:07:42] - [Mozilla 2020 layoffs](https://blog.mozilla.org/blog/2020/08/11/changing-world-changing-mozilla/)
-  - [Discussion on /r/rust](https://www.reddit.com/r/rust/comments/i7stjy/how_do_mozilla_layoffs_affect_rust/)
+- [@01:07:42] - [Mozilla 2020 layoffs](https://blog.mozilla.org/blog/2020/08/11/changing-world-changing-mozilla/){:target="_blank"}
+  - [Discussion on /r/rust](https://www.reddit.com/r/rust/comments/i7stjy/how_do_mozilla_layoffs_affect_rust/){:target="_blank"}
 - [@01:12:33] - Will Rust stay open-source?
 - [01:18:10] - Future of Rust
 - [01:24:48] - Who decides what changes make it into Rust?
 
 ## Credits
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/043-bastian-gruber.md
+++ b/_episodes/043-bastian-gruber.md
@@ -6,44 +6,44 @@ duration: "52:28"
 length: "51158078"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with [Bastian Gruber](https://github.com/gruberb), author of ["Rust Web Development"](https://www.rustwebdevelopment.com/), about his book.
+Allen Wyma talks with [Bastian Gruber](https://github.com/gruberb){:target="_blank"}, author of ["Rust Web Development"](https://www.rustwebdevelopment.com/){:target="_blank"}, about his book.
 
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
-- [@01:22] - [Bastian's Bio](https://twitter.com/recvonline)
-- [@02:53] - ["Rust Web Development" on Manning](https://www.manning.com/books/rust-web-development)
+- [@01:22] - [Bastian's Bio](https://twitter.com/recvonline){:target="_blank"}
+- [@02:53] - ["Rust Web Development" on Manning](https://www.manning.com/books/rust-web-development){:target="_blank"}
 - [@04:06] - Using Rust for web development 
-- [@04:52] - [Hyper.rs](https://hyper.rs/)
+- [@04:52] - [Hyper.rs](https://hyper.rs/){:target="_blank"}
 - [@05:13] - Choices of frameworks for Rust web development 
-- [@07:49] - [Rocket](https://rocket.rs/) in production
+- [@07:49] - [Rocket](https://rocket.rs/) in production{:target="_blank"}
 - [@08:35] - Tools for Rust web services
-- [@10:39] - Choosing [SQLx](https://github.com/launchbadge/sqlx) over [Diesel](https://diesel.rs/)?
-- [@13:58] - Why Bastian switched from [Node.js](https://nodejs.org/en/) to Rust
+- [@10:39] - Choosing [SQLx](https://github.com/launchbadge/sqlx) over [Diesel](https://diesel.rs/)?{:target="_blank"}
+- [@13:58] - Why Bastian switched from [Node.js](https://nodejs.org/en/) to Rust{:target="_blank"}
 - [@17:36] - Bastian's role at Twilio
 - [@19:57] - Popularity of Rust in Berlin
-- [@25:57] - [Warp](https://github.com/seanmonstar/warp)
-- [@29:14] - [Zero to Production in Rust](https://www.zero2prod.com/index.html)
+- [@25:57] - [Warp](https://github.com/seanmonstar/warp){:target="_blank"}
+- [@29:14] - [Zero to Production in Rust](https://www.zero2prod.com/index.html){:target="_blank"}
 - [@31:03] - How does Bastian write?
 - [@37:48] - Rust vs other languages
 - [@42:40] - Tips to help you stand out as a Rust developer
 - [@46:21] - Tips for beginners
 
 ## Credits
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/044-zach-lloyd.md
+++ b/_episodes/044-zach-lloyd.md
@@ -6,49 +6,49 @@ duration: "1:02:51"
 length: "61148368"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with [Zach Lloyd](https://twitter.com/zachlloydtweets), the founder of [Warp](https://www.warp.dev). Warp is a blazingly fast, Rust-based terminal that makes you and your team more productive.
+Allen Wyma talks with [Zach Lloyd](https://twitter.com/zachlloydtweets){:target="_blank"}, the founder of [Warp](https://www.warp.dev){:target="_blank"}. Warp is a blazingly fast, Rust-based terminal that makes you and your team more productive.
 
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
 - [@00:58] - Is Warp a GUI app?
 - [@04:08] - The history of Warp
-- [@06:27] - Difference between Warp and other Unix shells like [Csh](http://cshell.net/)
+- [@06:27] - Difference between Warp and other Unix shells like [Csh](http://cshell.net/){:target="_blank"}
 - [@10:22] - Warp's open API 
 - [@13:50] - Terminal improvements over the last 10 years
 - [@17:06] - Sharing blocks & live collaboration
 - [@19:08] - Will Warp run on multiple platforms?
 - [@21:45] - Zach's background
-- [@25:38] - Why Rust over [Go](https://golang.org/)?
+- [@25:38] - Why Rust over [Go](https://golang.org/)?{:target="_blank"}
 - [@29:51] - Warp's dependencies
 - [@36:36] - Objective-C vs. Rust
 - [@41:49] - Zach's build pipeline
-- [@43:21] - [`cargo-bundle`](https://github.com/burtonageo/cargo-bundle)
+- [@43:21] - [`cargo-bundle`](https://github.com/burtonageo/cargo-bundle){:target="_blank"}
 - [@44:52] - Warp's business model
-- [@46:28] - [Postman](https://www.postman.com/)
+- [@46:28] - [Postman](https://www.postman.com/){:target="_blank"}
 - [@49:50] - Funding & business pitch of Warp
 - [@54:30] - Zach's Rust setup
 - [@57:46] - Tips for newcomers to Rust 
 
 ## Other Resources
-- [Warp's Twitter](https://twitter.com/warpdotdev)
-- [Warp's GitHub](https://github.com/warpdotdev/warp)
-- [Zach's engineering handbook](https://thezbook.com/)
+- [Warp's Twitter](https://twitter.com/warpdotdev){:target="_blank"}
+- [Warp's GitHub](https://github.com/warpdotdev/warp){:target="_blank"}
+- [Zach's engineering handbook](https://thezbook.com/){:target="_blank"}
 ## Credits
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/045-sean-arthur.md
+++ b/_episodes/045-sean-arthur.md
@@ -6,45 +6,45 @@ duration: "1:05:18"
 length: "63525368"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with [Sean McArthur](https://twitter.com/seanmonstar), the creator of [Hyper](https://github.com/hyperium/hyper), an HTTP library for Rust.
+Allen Wyma talks with [Sean McArthur](https://twitter.com/seanmonstar){:target="_blank"}, the creator of [Hyper](https://github.com/hyperium/hyper){:target="_blank"}, an HTTP library for Rust.
 
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
 - [@01:37] - The history of Hyper
 - [@07:41] - Is Hyper a client or a server side component?
 - [@11:09] - Async/await
 - [@13:24] - Benefits to using async over blocking?
-- [@14:35] - Relationship between [Tokio](https://github.com/tokio-rs/tokio) and Hyper
-- [@16:11] - [Mio – Metal IO](https://github.com/tokio-rs/mio)
+- [@14:35] - Relationship between [Tokio](https://github.com/tokio-rs/tokio) and Hyper{:target="_blank"}
+- [@16:11] - [Mio – Metal IO](https://github.com/tokio-rs/mio){:target="_blank"}
 - [@16:48] - Can Hyper run on other async runtimes?
-- [@18:27] - [Fuchsia OS](https://fuchsia.dev/)
+- [@18:27] - [Fuchsia OS](https://fuchsia.dev/){:target="_blank"}
 - [@22:39] - Governance of the Hyper Project
 - [@25:25] - Why did Hyper choose Tokio?
-- [@34:35] - [Reqwest](https://github.com/seanmonstar/reqwest)
-- [@36:07] - [cURL](https://curl.se/)
+- [@34:35] - [Reqwest](https://github.com/seanmonstar/reqwest){:target="_blank"}
+- [@36:07] - [cURL](https://curl.se/){:target="_blank"}
 - [@38:29] - What is a C application binary interface (ABI)?
 - [@50:29] - HTTP/3 support in future
-- [@50:54] - Differences between [HTTP/2](https://http2.github.io/) and [HTTP/3](https://blog.cloudflare.com/http3-the-past-present-and-future/)
+- [@50:54] - Differences between [HTTP/2](https://http2.github.io/) and [HTTP/3](https://blog.cloudflare.com/http3-the-past-present-and-future/){:target="_blank"}
 - [@53:26] - Rust library for C
 - [@57:26] - Upcoming plan for Hyper
 - [@01:00:36] - Advice for newcomers to Rust?
 
 ## Credits
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/046-alice-ryhl.md
+++ b/_episodes/046-alice-ryhl.md
@@ -6,17 +6,17 @@ duration: "1:08:50"
 length: "66908058"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with [Alice Ryhl](https://ryhl.io/), one of the maintainers of the open source project [Tokio](https://tokio.rs/).
+Allen Wyma talks with [Alice Ryhl](https://ryhl.io/){:target="_blank"}, one of the maintainers of the open source project [Tokio](https://tokio.rs/){:target="_blank"}.
 
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
 - [@00:40] - Alice's Bio
@@ -27,37 +27,37 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 - [@12:55] - Changes in Tokio since Alice joined
 - [@16:52] - Measuring metrics
 - [@19:38] - Cooperative & preemptive scheduling
-- [@24:30] - [Diesel](https://diesel.rs/)
-- [@25:45] - Definition of [blocking]((https://ryhl.io/blog/async-what-is-blocking/)
+- [@24:30] - [Diesel](https://diesel.rs/){:target="_blank"}
+- [@25:45] - Definition of [blocking]((https://ryhl.io/blog/async-what-is-blocking/){:target="_blank"}
 - [@27:37] - I/O threads
 - [@31:21] - What are sleeping threads?
-- [@33:41] - [Tokio Console](https://tokio.rs/blog/2021-09-console-dev-diary-1)
+- [@33:41] - [Tokio Console](https://tokio.rs/blog/2021-09-console-dev-diary-1){:target="_blank"}
 - [@41:14] - Pros and cons of using actors
 - [@47:05] - Alice's academic background
 - [@49:22] - Tokio's upcoming roadmap
 - [@57:33] - Replacing epoll with io_uring
-- [@58:56] - [Axum](https://github.com/tokio-rs/axum), [Tower](https://github.com/tower-rs/tower), and [Loom](https://github.com/tokio-rs/loom)
+- [@58:56] - [Axum](https://github.com/tokio-rs/axum){:target="_blank"}, [Tower](https://github.com/tower-rs/tower){:target="_blank"}, and [Loom](https://github.com/tokio-rs/loom){:target="_blank"}
 - [@01:01:45] - Web frameworks for Rust
 - [@01:05:57] - How to contact Alice
 
 ## Other Resources 
-- [Rust in Android Platform](https://security.googleblog.com/2021/04/rust-in-android-platform.html)
-- [Tokio's Discord](https://discord.com/invite/tokio)
-- [Tokio's Topics Pages](https://tokio.rs/tokio/topics)
-- [Cooperative Scheduling](https://tokio.rs/blog/2020-04-preemption)
-- [Tokio Metrics](https://github.com/tokio-rs/tokio/issues/4073)
-- [Actors in Tokio](https://ryhl.io/blog/actors-with-tokio/)
-- [io_uring with Tokio](https://github.com/tokio-rs/tokio-uring/)
+- [Rust in Android Platform](https://security.googleblog.com/2021/04/rust-in-android-platform.html){:target="_blank"}
+- [Tokio's Discord](https://discord.com/invite/tokio){:target="_blank"}
+- [Tokio's Topics Pages](https://tokio.rs/tokio/topics){:target="_blank"}
+- [Cooperative Scheduling](https://tokio.rs/blog/2020-04-preemption){:target="_blank"}
+- [Tokio Metrics](https://github.com/tokio-rs/tokio/issues/4073){:target="_blank"}
+- [Actors in Tokio](https://ryhl.io/blog/actors-with-tokio/){:target="_blank"}
+- [io_uring with Tokio](https://github.com/tokio-rs/tokio-uring/){:target="_blank"}
 
 ## Credits
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/047-jane-lusby.md
+++ b/_episodes/047-jane-lusby.md
@@ -6,38 +6,38 @@ duration: "52:58"
 length: "51684453"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with [Jane Lusby](https://github.com/yaahc), the Error Handling Project Group Lead, and also the Project Director of Collaboration at [Rust Foundation](https://foundation.rust-lang.org/). 
+Allen Wyma talks with [Jane Lusby](https://github.com/yaahc){:target="_blank"}, the Error Handling Project Group Lead, and also the Project Director of Collaboration at [Rust Foundation](https://foundation.rust-lang.org/){:target="_blank"}.
 
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
 - [@00:57] - Jane's bio
-- [@04:10] - Jane's contributions to [Clippy](https://github.com/rust-lang/rust-clippy)
-- [@08:54] - [Eyre](https://github.com/yaahc/eyre)
-- [@15:49] - [Failure](https://docs.rs/failure/) & [Anyhow](https://docs.rs/anyhow/)
+- [@04:10] - Jane's contributions to [Clippy](https://github.com/rust-lang/rust-clippy){:target="_blank"}
+- [@08:54] - [Eyre](https://github.com/yaahc/eyre){:target="_blank"}
+- [@15:49] - [Failure](https://docs.rs/failure/){:target="_blank"}  & [Anyhow](https://docs.rs/anyhow/){:target="_blank"}
 - [@17:13] - Choosing between anyhow & eyre
-- [@20:05] - [AnyError](https://docs.rs/err-context/0.1/err_context/type.AnyError.html) and [ThisError](https://docs.rs/thiserror/)
-- [@23:31] - [Color-eyre](https://github.com/yaahc/color-eyre)
+- [@20:05] - [AnyError](https://docs.rs/err-context/0.1/err_context/type.AnyError.html){:target="_blank"}  and [ThisError](https://docs.rs/thiserror/){:target="_blank"}
+- [@23:31] - [Color-eyre](https://github.com/yaahc/color-eyre){:target="_blank"}
 - [@26:08] - Other crates that are also in eyre
-- [@28:59] - [Error Handling Group](https://github.com/rust-lang/project-error-handling)
+- [@28:59] - [Error Handling Group](https://github.com/rust-lang/project-error-handling){:target="_blank"}
 - [@38:12] - Collaboration with other groups 
 - [@46:05] - Rust 2021 & 2018 Editions
 
 ## Credits
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/048-herbert-wolverson.md
+++ b/_episodes/048-herbert-wolverson.md
@@ -6,52 +6,52 @@ duration: "1:05:00"
 length: "63273551"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with [Herbert Wolverson](https://twitter.com/herberticus), the author of the book [Hands-on Rust](https://pragprog.com/titles/hwrust/hands-on-rust/).
+Allen Wyma talks with [Herbert Wolverson](https://twitter.com/herberticus){:target="_blank"}, the author of the book [Hands-on Rust](https://pragprog.com/titles/hwrust/hands-on-rust/){:target="_blank"}.
 
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
-- [@0:57] - About Herbert and his [book](https://pragprog.com/titles/hwrust/hands-on-rust/)
-- [@3:01] - Explaining Rust's [traits](https://doc.rust-lang.org/book/ch10-02-traits.html)
+- [@0:57] - About Herbert and his [book](https://pragprog.com/titles/hwrust/hands-on-rust/){:target="_blank"}
+- [@3:01] - Explaining Rust's [traits](https://doc.rust-lang.org/book/ch10-02-traits.html){:target="_blank"}
 - [@4:27] - The book is for intermediate programming
 - [@5:32] - Most beneficial part about using Rust over other languages
-- [@7:42] - [Unreal Engine](https://www.unrealengine.com/)
-- [@11:13] - Unreal, [Unity](https://unity.com/) & [Godot](https://godotengine.org/)
-- [@13:44] - [Bevy](https://bevyengine.org/) Engine & [Amethyst](https://amethyst.rs/) Engine
-- [@18:31] - [Zig](https://ziglang.org/)
-- [@20:38] - Herbert's [Bracket-Lib](https://bracketproductions.com/) engine
+- [@7:42] - [Unreal Engine](https://www.unrealengine.com/){:target="_blank"}
+- [@11:13] - Unreal, [Unity](https://unity.com/){:target="_blank"} & [Godot](https://godotengine.org/){:target="_blank"}
+- [@13:44] - [Bevy](https://bevyengine.org/){:target="_blank"} Engine & [Amethyst](https://amethyst.rs/){:target="_blank"} Engine
+- [@18:31] - [Zig](https://ziglang.org/){:target="_blank"}
+- [@20:38] - Herbert's [Bracket-Lib](https://bracketproductions.com/){:target="_blank"} engine
 - [@24:18] - Creating a game engine from scratch
 - [@34:03] - ECS (Entity Component System) & OPP (Object-Oriented Programming)
 - [@42:02] - Other game engines mentioned in the book
 - [@43:12] - Macroquad & Miniquad
 - [@45:39] - Amethyst
-- [@49:51] - [RG3D](https://rg3d.rs/)
-- [@51:58] - Book Status & [Rust Brain Teasers](https://pragprog.com/titles/hwrustbrain/rust-brain-teasers/)
-- [@57:44] - [Pragprog](https://pragprog.com/) Publishing
+- [@49:51] - [RG3D](https://rg3d.rs/){:target="_blank"}
+- [@51:58] - Book Status & [Rust Brain Teasers](https://pragprog.com/titles/hwrustbrain/rust-brain-teasers/){:target="_blank"}
+- [@57:44] - [Pragprog](https://pragprog.com/){:target="_blank"} Publishing
 - [@01:02:30] - How to contact Herbert
 
 ## Other Resources
-- [Hands-on Rust](https://hands-on-rust.com/)
-- [Roguelike Tutorial](https://github.com/amethyst/rustrogueliketutorial)
-- [The Bracket](https://github.com/thebracket/)
+- [Hands-on Rust](https://hands-on-rust.com/){:target="_blank"}
+- [Roguelike Tutorial](https://github.com/amethyst/rustrogueliketutorial){:target="_blank"}
+- [The Bracket](https://github.com/thebracket/){:target="_blank"}
 
 ## Credits
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/049-lily-mara.md
+++ b/_episodes/049-lily-mara.md
@@ -6,22 +6,22 @@ duration: "0:57:18"
 length: "55910810"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with [Lily Mara](https://twitter.com/TheLily_Mara), the author of the book [Refactoring to Rust](https://www.manning.com/books/refactoring-to-rust).
+Allen Wyma talks with [Lily Mara](https://twitter.com/TheLily_Mara){:target="_blank"}, the author of the book [Refactoring to Rust](https://www.manning.com/books/refactoring-to-rust){:target="_blank"}.
 
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
 - [@1:26] -	Lily's Bio
-- [@3:33] -	Her [blogs](https://onesignal.com/blog/author/lily/) helped her improve her writing
-- [@5:09] -	How the [book](https://www.manning.com/books/refactoring-to-rust) came to be
+- [@3:33] -	Her [blogs](https://onesignal.com/blog/author/lily/){:target="_blank"} helped her improve her writing
+- [@5:09] -	How the [book](https://www.manning.com/books/refactoring-to-rust){:target="_blank"} came to be
 - [@9:34] -	Knowing when to add a new language to an existing project
 - [@12:07] - Tools for measuring memory usage
 - [@15:04] - Garbage collection
@@ -38,16 +38,16 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 - [@53:07] - Lily's advice for aspiring Rust developers
 
 ## Other Resources
-- [PyO3](https://github.com/PyO3/pyo3)
-- [Flutter Rust Bridge](https://github.com/fzyzcjy/flutter_rust_bridge)
+- [PyO3](https://github.com/PyO3/pyo3){:target="_blank"}
+- [Flutter Rust Bridge](https://github.com/fzyzcjy/flutter_rust_bridge){:target="_blank"}
 
 ## Credits
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}

--- a/_episodes/050-rust-1.56-1.57.md
+++ b/_episodes/050-rust-1.56-1.57.md
@@ -22,82 +22,82 @@ paragraphs show up as "expanded description".
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
- - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
- - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
- - Github: [@rustacean-station](https://github.com/rustacean-station/)
- - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+ - Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+ - Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+ - Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+ - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ### Timestamps & referenced resources
 
-#### [@01:14] - [Rust 2021 edition](https://doc.rust-lang.org/stable/edition-guide/rust-2021/index.html)
+#### [@01:14] - [Rust 2021 edition](https://doc.rust-lang.org/stable/edition-guide/rust-2021/index.html){:target="_blank"}
 
- - [@01:16] - [What is an edition?](https://rust-lang.github.io/rfcs/3085-edition-2021.html)
- - [@05:03] - [Disjoint captures in closures](https://doc.rust-lang.org/stable/edition-guide/rust-2021/disjoint-capture-in-closures.html)
-     - [Niko's "view types" proposal](https://smallcultfollowing.com/babysteps//blog/2021/11/05/view-types/)
- - [@09:00] - [`IntoIterator` for arrays](https://doc.rust-lang.org/stable/edition-guide/rust-2021/IntoIterator-for-arrays.html)
- - [@11:12] - [Or patterns in macro_rules](https://doc.rust-lang.org/stable/edition-guide/rust-2021/or-patterns-macro-rules.html)
- - [@13:31] - [New default Cargo feature resolver](https://doc.rust-lang.org/stable/edition-guide/rust-2021/default-cargo-resolver.html)
-     - [Details on the new resolver](https://doc.rust-lang.org/stable/cargo/reference/resolver.html#feature-resolver-version-2)
- - [@15:16] - [Additions to the prelude](https://doc.rust-lang.org/stable/edition-guide/rust-2021/prelude.html)
-     - [`std::prelude`](https://doc.rust-lang.org/stable/std/prelude/index.html)
-     - [`FromIterator`](https://doc.rust-lang.org/stable/std/iter/trait.FromIterator.html)
- - [@19:38] - [Panic macro consistency](https://doc.rust-lang.org/stable/edition-guide/rust-2021/panic-macro-consistency.html) and [new reserved syntax](https://doc.rust-lang.org/stable/edition-guide/rust-2021/reserving-syntax.html)
-     - [@20:33] - [Implicit formatting captures](https://rust-lang.github.io/rfcs/2795-format-args-implicit-identifiers.html) (more [on Reddit](https://www.reddit.com/r/rust/comments/qu3cli/pr_to_stabilize_implicit_captures_in_string/))
+ - [@01:16] - [What is an edition?](https://rust-lang.github.io/rfcs/3085-edition-2021.html){:target="_blank"}
+ - [@05:03] - [Disjoint captures in closures](https://doc.rust-lang.org/stable/edition-guide/rust-2021/disjoint-capture-in-closures.html){:target="_blank"}
+     - [Niko's "view types" proposal](https://smallcultfollowing.com/babysteps//blog/2021/11/05/view-types/){:target="_blank"}
+ - [@09:00] - [`IntoIterator` for arrays](https://doc.rust-lang.org/stable/edition-guide/rust-2021/IntoIterator-for-arrays.html){:target="_blank"}
+ - [@11:12] - [Or patterns in macro_rules](https://doc.rust-lang.org/stable/edition-guide/rust-2021/or-patterns-macro-rules.html){:target="_blank"}
+ - [@13:31] - [New default Cargo feature resolver](https://doc.rust-lang.org/stable/edition-guide/rust-2021/default-cargo-resolver.html){:target="_blank"}
+     - [Details on the new resolver](https://doc.rust-lang.org/stable/cargo/reference/resolver.html#feature-resolver-version-2){:target="_blank"}
+ - [@15:16] - [Additions to the prelude](https://doc.rust-lang.org/stable/edition-guide/rust-2021/prelude.html){:target="_blank"}
+     - [`std::prelude`](https://doc.rust-lang.org/stable/std/prelude/index.html){:target="_blank"}
+     - [`FromIterator`](https://doc.rust-lang.org/stable/std/iter/trait.FromIterator.html){:target="_blank"}
+ - [@19:38] - [Panic macro consistency](https://doc.rust-lang.org/stable/edition-guide/rust-2021/panic-macro-consistency.html){:target="_blank"} and [new reserved syntax](https://doc.rust-lang.org/stable/edition-guide/rust-2021/reserving-syntax.html){:target="_blank"}
+     - [@20:33] - [Implicit formatting captures](https://rust-lang.github.io/rfcs/2795-format-args-implicit-identifiers.html){:target="_blank"} (more [on Reddit](https://www.reddit.com/r/rust/comments/qu3cli/pr_to_stabilize_implicit_captures_in_string/)){:target="_blank"}
      - [@25:00] - Reserved syntax for "f-strings"
      - [@27:54] - Why `panic!` had to change
      - [@28:55] - Other uses for reserved syntax
- - [@30:15] - [Warnings promoted to errors](https://doc.rust-lang.org/stable/edition-guide/rust-2021/warnings-promoted-to-error.html)
-     - [Future incompatibility warnings](https://rust-lang.github.io/rfcs/2834-cargo-report-future-incompat.html)
- - [@35:23] - [`cargo fix`](https://doc.rust-lang.org/stable/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html)
+ - [@30:15] - [Warnings promoted to errors](https://doc.rust-lang.org/stable/edition-guide/rust-2021/warnings-promoted-to-error.html){:target="_blank"}
+     - [Future incompatibility warnings](https://rust-lang.github.io/rfcs/2834-cargo-report-future-incompat.html){:target="_blank"}
+ - [@35:23] - [`cargo fix`](https://doc.rust-lang.org/stable/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html){:target="_blank"}
 
-#### [@36:20] - [Rust 1.56](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)
+#### [@36:20] - [Rust 1.56](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html){:target="_blank"}
 
- - [@36:30] - [Cargo.toml `rust-version`](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html#cargo-rust-version)
-     - [Cargo book entry](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
- - [@42:54] - [New bindings in `binding @ pattern`](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html#new-bindings-in-binding--pattern)
- - [@44:27] - [Stabilized APIs](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html#stabilized-apis)
+ - [@36:30] - [Cargo.toml `rust-version`](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html#cargo-rust-version){:target="_blank"}
+     - [Cargo book entry](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field){:target="_blank"}
+ - [@42:54] - [New bindings in `binding @ pattern`](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html#new-bindings-in-binding--pattern){:target="_blank"}
+ - [@44:27] - [Stabilized APIs](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html#stabilized-apis){:target="_blank"}
  - [@49:27] - Changelog deep-dive
      - [@49:27] - [`impl From<[(K, V), N]>` for collections](https://github.com/rust-lang/rust/pull/84111)
-       - [RFC for adding collection literal macros](https://github.com/rust-lang/rfcs/issues/542)
-     - [@53:07] - [Remove `P: Unpin` bound on `impl Future for Pin`](https://github.com/rust-lang/rust/pull/81363)
-     - [@55:16] - [Instant backsliding protection optimization](https://github.com/rust-lang/rust/pull/83093)
-       - [May end up being removed!](https://github.com/rust-lang/rust/pull/89926)
-     - [@58:01] - [LLVM 13 upgrade](https://github.com/rust-lang/rust/pull/87570)
-       - [LLVM's new pass manager](https://blog.llvm.org/posts/2021-03-26-the-new-pass-manager/)
-     - [@59:23] - [Have Cargo set environment variables](https://doc.rust-lang.org/nightly/cargo/reference/config.html#env)
- - [@1:00:17] - [Rust 1.56.1](https://blog.rust-lang.org/2021/11/01/Rust-1.56.1.html)
-     - [Security advisory](https://blog.rust-lang.org/2021/11/01/cve-2021-42574.html)
-     - [The "Trojan Source" vulnerability](https://trojansource.codes/)
-     - [Rust RFC on non-ASCII identifiers](https://rust-lang.github.io/rfcs/2457-non-ascii-idents.html)
+       - [RFC for adding collection literal macros](https://github.com/rust-lang/rfcs/issues/542){:target="_blank"}
+     - [@53:07] - [Remove `P: Unpin` bound on `impl Future for Pin`](https://github.com/rust-lang/rust/pull/81363){:target="_blank"}
+     - [@55:16] - [Instant backsliding protection optimization](https://github.com/rust-lang/rust/pull/83093){:target="_blank"}
+       - [May end up being removed!](https://github.com/rust-lang/rust/pull/89926){:target="_blank"}
+     - [@58:01] - [LLVM 13 upgrade](https://github.com/rust-lang/rust/pull/87570){:target="_blank"}
+       - [LLVM's new pass manager](https://blog.llvm.org/posts/2021-03-26-the-new-pass-manager/){:target="_blank"}
+     - [@59:23] - [Have Cargo set environment variables](https://doc.rust-lang.org/nightly/cargo/reference/config.html#env){:target="_blank"}
+ - [@1:00:17] - [Rust 1.56.1](https://blog.rust-lang.org/2021/11/01/Rust-1.56.1.html){:target="_blank"}
+     - [Security advisory](https://blog.rust-lang.org/2021/11/01/cve-2021-42574.html){:target="_blank"}
+     - [The "Trojan Source" vulnerability](https://trojansource.codes/){:target="_blank"}
+     - [Rust RFC on non-ASCII identifiers](https://rust-lang.github.io/rfcs/2457-non-ascii-idents.html){:target="_blank"}
 
-#### [@1:04:52] - [Rust 1.57](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html)
+#### [@1:04:52] - [Rust 1.57](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html){:target="_blank"}
 
- - [@1:05:20] - [Panic in const contexts](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#panic-in-const-contexts)
- - [@1:07:20] - [Custom Cargo profiles](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#cargo-support-for-custom-profiles)
-     - [Cargo book on profiles](https://doc.rust-lang.org/cargo/reference/profiles.html)
- - [@1:08:45] - [Fallible allocation](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#fallible-allocation)
-     - [Fallible collection allocation RFC](https://rust-lang.github.io/rfcs/2116-alloc-me-maybe.html)
-     - [Linux Torvals on handling allocation failures](https://lkml.org/lkml/2021/4/14/1099)
-     - [Rust features still needed by the Linux kernel](https://github.com/Rust-for-Linux/linux/issues/2)
- - [@1:12:33] - [Stabilized APIs](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#stabilized-apis)
+ - [@1:05:20] - [Panic in const contexts](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#panic-in-const-contexts){:target="_blank"}
+ - [@1:07:20] - [Custom Cargo profiles](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#cargo-support-for-custom-profiles){:target="_blank"}
+     - [Cargo book on profiles](https://doc.rust-lang.org/cargo/reference/profiles.html){:target="_blank"}
+ - [@1:08:45] - [Fallible allocation](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#fallible-allocation){:target="_blank"}
+     - [Fallible collection allocation RFC](https://rust-lang.github.io/rfcs/2116-alloc-me-maybe.html){:target="_blank"}
+     - [Linux Torvals on handling allocation failures](https://lkml.org/lkml/2021/4/14/1099){:target="_blank"}
+     - [Rust features still needed by the Linux kernel](https://github.com/Rust-for-Linux/linux/issues/2){:target="_blank"}
+ - [@1:12:33] - [Stabilized APIs](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#stabilized-apis){:target="_blank"}
  - [@1:16:45] - Changelog deep-dive
-     - [@1:16:50] - [`Vec::leak` no longer allocates](https://github.com/rust-lang/rust/pull/89337/)
-     - [@1:18:03] - [Nintendo 3DS added as Tier 3 platform](https://github.com/rust-lang/rust/pull/88529/)
-     - [@1:19:03] - [Cargo no longer passes through `RUSTFLAGS`](https://github.com/rust-lang/cargo/issues/10111)
-         - [Environment variables set by Cargo](https://doc.rust-lang.org/nightly/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts)
-     - [@1:20:13] - [Lots more `#[must_use]` in `std`](https://github.com/rust-lang/rust/issues/89692/)
-     - [@1:22:00] - [`File::read_to_*` optimized](https://github.com/rust-lang/rust/pull/89582/)
-     - [@1:23:24] - [Curly braces macros accept following `.` and `?`](https://github.com/rust-lang/rust/pull/88690/)
+     - [@1:16:50] - [`Vec::leak` no longer allocates](https://github.com/rust-lang/rust/pull/89337/){:target="_blank"}
+     - [@1:18:03] - [Nintendo 3DS added as Tier 3 platform](https://github.com/rust-lang/rust/pull/88529/){:target="_blank"}
+     - [@1:19:03] - [Cargo no longer passes through `RUSTFLAGS`](https://github.com/rust-lang/cargo/issues/10111){:target="_blank"}
+         - [Environment variables set by Cargo](https://doc.rust-lang.org/nightly/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts){:target="_blank"}
+     - [@1:20:13] - [Lots more `#[must_use]` in `std`](https://github.com/rust-lang/rust/issues/89692/){:target="_blank"}
+     - [@1:22:00] - [`File::read_to_*` optimized](https://github.com/rust-lang/rust/pull/89582/){:target="_blank"}
+     - [@1:23:24] - [Curly braces macros accept following `.` and `?`](https://github.com/rust-lang/rust/pull/88690/){:target="_blank"}
  - [@1:25:22] - Banter -- Rust all the way down.
 
 ### Credits
 
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Jeremy Jung](https://www.softwaresessions.com)
+Audio Editing: [Jeremy Jung](https://www.softwaresessions.com){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Jon Gjengset](https://twitter.com/jonhoo/)
+Show Notes: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
 Hosts: Jon Gjengset and Ben Striegel

--- a/_episodes/051-brenden-matthews.md
+++ b/_episodes/051-brenden-matthews.md
@@ -6,30 +6,30 @@ duration: "1:02:23"
 length: "60817752"
 #reddit: (leave blank on initial publish, amend with link and uncomment this line after Reddit thread has been posted)
 ---
-Allen Wyma talks with [Brenden Matthews](https://twitter.com/brndnmtthws), the author of the book [Code Like a Pro in Rust](https://www.manning.com/books/code-like-a-pro-in-rust).
+Allen Wyma talks with [Brenden Matthews](https://twitter.com/brndnmtthws){:target="_blank"}, the author of the book [Code Like a Pro in Rust](https://www.manning.com/books/code-like-a-pro-in-rust){:target="_blank"}.
 
 
 ## Contributing to Rustacean Station
 
 Rustacean Station is a community project; get in touch with us if you'd like to suggest an idea for an episode or offer your services as a host or audio editor!
 
-- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm)
-- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc)
-- Github: [@rustacean-station](https://github.com/rustacean-station/)
-- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
+- Twitter: [@rustaceanfm](https://twitter.com/rustaceanfm){:target="_blank"}
+- Discord: [Rustacean Station](https://discord.gg/cHc3Gyc){:target="_blank"}
+- Github: [@rustacean-station](https://github.com/rustacean-station/){:target="_blank"}
+- Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org){:target="_blank"}
 
 ## Timestamps 
 - [@0:41] -	Brenden's Bio
-- [@1:30] -	Where the idea to write the [book](https://www.manning.com/books/code-like-a-pro-in-rust?utm_source=brendenm&utm_medium=affiliate&utm_campaign=book_matthews_code_9_22_21&a_aid=brendenm&a_bid=3eb61509) came from
+- [@1:30] -	Where the idea to write the [book](https://www.manning.com/books/code-like-a-pro-in-rust?utm_source=brendenm&utm_medium=affiliate&utm_campaign=book_matthews_code_9_22_21&a_aid=brendenm&a_bid=3eb61509){:target="_blank"} came from
 - [@4:32] -	Pythonic, Rustacious/Idiomatic Rust and other coding style terms
 - [@6:25] -	Writing idiomatic code
 - [@10:19] - Helper methods
-- [@12:34] - [From](https://doc.rust-lang.org/std/convert/trait.From.html) trait	
-- [@15:20] - [Into](https://doc.rust-lang.org/std/convert/trait.Into.html) trait	
+- [@12:34] - [From](https://doc.rust-lang.org/std/convert/trait.From.html){:target="_blank"} trait
+- [@15:20] - [Into](https://doc.rust-lang.org/std/convert/trait.Into.html){:target="_blank"} trait
 - [@17:00] - Errors	in Rust
 - [@26:59] - Other languages borrowing Rust's ideas for memory safety and no null type	
-- [@29:21] - [Kotlin](https://kotlinlang.org/), [Dart](https://dart.dev/), [Swift](https://developer.apple.com/swift/) & [Zig](https://ziglang.org/)	
-- [@30:58] - [LLVM](https://www.llvm.org/), Swift & Rust and evolution of languages
+- [@29:21] - [Kotlin](https://kotlinlang.org/){:target="_blank"}, [Dart](https://dart.dev/){:target="_blank"}, [Swift](https://developer.apple.com/swift/){:target="_blank"} & [Zig](https://ziglang.org/){:target="_blank"}
+- [@30:58] - [LLVM](https://www.llvm.org/){:target="_blank"}, Swift & Rust and evolution of languages
 - [@35:32] - Backwards compatibility in Rust
 - [@39:00] - Experiences and the improvements in Rust
 - [@42:44] - Components are added manually, but should they be installed by default?
@@ -37,15 +37,15 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 - [@59:58] - Who Code Like a Pro in Rust is written for
 
 ## Other Resources
-- [Brenden's Blog](https://brndn.io/)
+- [Brenden's Blog](https://brndn.io/){:target="_blank"}
 
 ## Credits
-Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
+Intro Theme: [Aerocity](https://twitter.com/AerocityMusic){:target="_blank"}
 
-Audio Editing: [Plangora](https://twitter.com/plangora)
+Audio Editing: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
+Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/){:target="_blank"}
 
-Show Notes: [Plangora](https://twitter.com/plangora)
+Show Notes: [Plangora](https://twitter.com/plangora){:target="_blank"}
 
-Hosts: [Allen Wyma](https://twitter.com/allenwyma)
+Hosts: [Allen Wyma](https://twitter.com/allenwyma){:target="_blank"}


### PR DESCRIPTION
add `{:target="_blank"}` on links in references and show notes. In desktop browser on clicking the links it stops the podcast and opens the link in the same tab. Its better to listen to them and at the same time follow through resources in new tab, pin them etc..