### PR TITLE
Remove `display: block` from the header image

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,7 @@
 		<h1>
 		<a href="/">
 			The {{ site.title | default: site.github.repository_name }} Podcast
+			<br>
 			<img
 			 srcset="
 			  /images/artwork.jpg 3000w,

--- a/style.css
+++ b/style.css
@@ -20,7 +20,6 @@ body > h1 {
 }
 	body > h1 img {
 		max-height: 25vh;
-		display: block;
 		margin: 1em auto 0;
 		border: 5px solid white;
 	}


### PR DESCRIPTION
So many times I have accidentally clicked in the empty space next to the image and I had to navigate back to the podcast I was listening to. 