### PR TITLE
work around python-markdown bug

### DIFF
--- a/_episodes/releases/2022-10-05-rust-1.62-1.63-1.64.md
+++ b/_episodes/releases/2022-10-05-rust-1.62-1.63-1.64.md
@@ -79,7 +79,7 @@ Not much to talk about. We also didn't talk about:
    - [`cargo --config`](https://doc.rust-lang.org/nightly/cargo/reference/config.html#command-line-overrides)
    - [`cargo new` test code updated](https://github.com/rust-lang/cargo/pull/10706)
    - New targets: [Apple WatchOS](https://github.com/rust-lang/rust/pull/95243/) and [Nintendo 3DS](https://github.com/rust-lang/rust/pull/95897/)
-   - [`[OsStr]::join`](https://github.com/rust-lang/rust/pull/96881/)
+   - [`[OsStr]::join`](https://github.com/rust-lang/rust/pull/96881/) &nbsp;
      - [The `Join` trait](https://doc.rust-lang.org/std/slice/trait.Join.html)
 
 #### [@1:00:24] - [Rust 1.64](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html)


### PR DESCRIPTION
[Certain patterns](https://github.com/Python-Markdown/markdown/issues/1209) within links get eaten by older versions of the python-markdown parser. If you look at [the page for this episode](https://rustacean-station.org/episode/rust-1.62-1.63-1.64/), this text and its link are currently missing.

This bug can be worked around by adding an `&nbsp;` to the end of the list item. I've encountered this same bug a few times in the TWiR repository, and this is the least ugly workaround I've come up with so far. :shrug:

It can also be fixed for good by upgrading the python-markdown package to 3.3.7 or newer.  If you can, I recommend doing that instead, because there are probably more of these hiding out.