### PR TITLE
Move to Python 3 maybe?

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -90,6 +90,13 @@ jobs:
         url: https://rustacean-station.org' \
                _config.yml
         bundle exec jekyll build
+    - name: Grab feed validator
+      run: |
+        git clone https://github.com/w3c/feedvalidator.git
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+        cache: 'pip'
     - name: Validate feed
       run: |
         # Fix Ubuntu MIME type for RSS
@@ -101,8 +108,8 @@ jobs:
                -e '/xmlns:content/a \
                     xml:base="https://rustacean-station.org"' \
                validate.rss
-        git clone https://github.com/w3c/feedvalidator.git
         cd feedvalidator
+        pip install -r requirements.txt
         if ! python src/demo.py ../validate.rss; then
           cat ../validate.rss
           exit 1

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -12,15 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '2.x'
     - name: Dates are valid
       run: |
         pip install pytz ciso8601
         for episode in _episodes/*/*.md; do
           date=$(grep 'date:' "$episode" | head -n1 | sed 's/^date: //')
-          if ! python2 -c "import ciso8601; ciso8601.parse_rfc3339('$date');"; then
+          if ! python -c "import ciso8601; ciso8601.parse_rfc3339('$date');"; then
             echo "$episode: bad date '$date'"
             exit 1
           fi
@@ -104,9 +101,9 @@ jobs:
                -e '/xmlns:content/a \
                     xml:base="https://rustacean-station.org"' \
                validate.rss
-        git clone https://github.com/rubys/feedvalidator.git
+        git clone https://github.com/w3c/feedvalidator.git
         cd feedvalidator
-        if ! python2 src/demo.py ../validate.rss; then
+        if ! python src/demo.py ../validate.rss; then
           cat ../validate.rss
           exit 1
         fi


### PR DESCRIPTION
Newest Ubuntu (which GitHub CI has now moved to) doesn't even have 2.

This also moves us to https://github.com/w3c/feedvalidator/, which is a fork of rubys original version that, among other things, supports Python 3.