### PR TITLE
docs: fix typo for Fermyon

### DIFF
--- a/_episodes/interviews/2023-01-08-matt-butcher.md
+++ b/_episodes/interviews/2023-01-08-matt-butcher.md
@@ -26,7 +26,7 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 - [@30:27] - [Krustlet](https://krustlet.dev/)
 - [@36:21] - Edge Computing
 - [@41:05] - Fermyon Cloud
-- [@50:48] - Where to learn more about Fremyon Cloud
+- [@50:48] - Where to learn more about Fermyon Cloud
 - [@52:58] - Parting thoughts
 
 ## Credits


### PR DESCRIPTION
Actually I found it out because I misspelled the name myself in Github search bar... so the typo actually helped me to find what I was looking for.

Ps: I really love the podcast, thanks a lot for the nice content :)