### PR TITLE
fix timestamp formatting in recent interviews

### DIFF
--- a/_episodes/interviews/2023-09-28-ian-ker-sey.md
+++ b/_episodes/interviews/2023-09-28-ian-ker-sey.md
@@ -20,17 +20,17 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 
 ## Timestamps
 
-[@00:00] Guest introduction: Ian Ker-Seymer - Staff Software Engineer at [Shopify](https://www.shopify.com/)
-[@02:04] The connection between [Liquid](https://shopify.github.io/liquid/) and Shopify
-[@06:19] The nenefits of using WebAssembly
-[@11:14] Exploring the languages in Shopify's stack, including Ruby
-[@14:24] Rust's practical use cases
-[@16:44] How Rust became part of Shopify's stack
-[@19:14] Deep dive into rb-sys
-[@24:17] RubyGems and Bundler: insights and considerations
-[@36:41] Integrating Rust into the stack
-[@40:52] Addressing challenges with Windows compilation
-[@47:46] Spotlight on [rb-sys](https://github.com/oxidize-rb/rb-sys): why it's worth exploring
+- [@00:00] - Guest introduction: Ian Ker-Seymer - Staff Software Engineer at [Shopify](https://www.shopify.com/)
+- [@02:04] - The connection between [Liquid](https://shopify.github.io/liquid/) and Shopify
+- [@06:19] - The nenefits of using WebAssembly
+- [@11:14] - Exploring the languages in Shopify's stack, including Ruby
+- [@14:24] - Rust's practical use cases
+- [@16:44] - How Rust became part of Shopify's stack
+- [@19:14] - Deep dive into rb-sys
+- [@24:17] - RubyGems and Bundler: insights and considerations
+- [@36:41] - Integrating Rust into the stack
+- [@40:52] - Addressing challenges with Windows compilation
+- [@47:46] - Spotlight on [rb-sys](https://github.com/oxidize-rb/rb-sys): why it's worth exploring
 
 ## Credits
 

--- a/_episodes/interviews/2023-10-05-dave-macleod.md
+++ b/_episodes/interviews/2023-10-05-dave-macleod.md
@@ -21,21 +21,22 @@ Rustacean Station is a community project; get in touch with us if you'd like to 
 - Email: [hello@rustacean-station.org](mailto:hello@rustacean-station.org)
 
 ## Timestamps
-[@00:00] Introduction: meet Dave MacLeod
-[@01:47] Target audience and motivation behind the book
-[@08:32] Taking a direct approach to learning
-[@15:14] Understanding shadowing in Rust
-[@16:56] Comparing "Learn Rust in a Month of Lunches" with "EasyRust"
-[@20:06] Streamlined printing: Changes to `printline` and `print` in Rust
-[@22:08] Dive into async Rust
-[@24:19] Crafting a coherent flow: process and concept tie-ins in the book
-[@29:46] Tackling advanced topics: macros, iterators, and closures
-[@33:05] Exploring the `chrono` crate
-[@35:29] Safety and testing: discussing unsafe Rust
-[@41:49] The book's release date
-[@44:18] Dave's experience writing the book
-[@46:54] Future plans and projects
-[@49:33] Closing thoughts
+
+- [@00:00] - Introduction: meet Dave MacLeod
+- [@01:47] - Target audience and motivation behind the book
+- [@08:32] - Taking a direct approach to learning
+- [@15:14] - Understanding shadowing in Rust
+- [@16:56] - Comparing "Learn Rust in a Month of Lunches" with "EasyRust"
+- [@20:06] - Streamlined printing: Changes to `printline` and `print` in Rust
+- [@22:08] - Dive into async Rust
+- [@24:19] - Crafting a coherent flow: process and concept tie-ins in the book
+- [@29:46] - Tackling advanced topics: macros, iterators, and closures
+- [@33:05] - Exploring the `chrono` crate
+- [@35:29] - Safety and testing: discussing unsafe Rust
+- [@41:49] - The book's release date
+- [@44:18] - Dave's experience writing the book
+- [@46:54] - Future plans and projects
+- [@49:33] - Closing thoughts
 
 ## Credits
 


### PR DESCRIPTION
These need to be markdown lists, or they don't render correctly.

Also, insert the dash between the timestamp and note, to match the formatting of all the other episodes.

Fixes #231.

cc @allenwyma 