### PR TITLE
gitignore .bak and .swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /vendor/
 /.bundle/
 /Gemfile.lock
+*.bak
+*.swp


### PR DESCRIPTION
.bak created by the spell checker
.swp created by vim