### PR TITLE
Adds episode data for AccessKit episode

### DIFF
--- a/_episodes/interviews/2025-05-29-accesskit-with-matt-campbell-and-arnold-loubriat.md
+++ b/_episodes/interviews/2025-05-29-accesskit-with-matt-campbell-and-arnold-loubriat.md
@@ -59,6 +59,15 @@ Intro Theme: [Aerocity](https://twitter.com/AerocityMusic)
 
 Audio Editing: Luuk van der Duim
 
+Samples used in interruption:
+
+- ["Vinyl - 45RPM - Start 2"](https://freesound.org/people/day-garwood/sounds/619302/)
+  by: [day-garwood](https://freesound.org/people/day-garwood/)
+  License: [Attribution 3.0](https://creativecommons.org/licenses/by/3.0/)
+- [Record Scratch #3](https://freesound.org/people/musicvision31/sounds/431778/)
+  by: [musicvision31](https://freesound.org/people/musicvision31/)
+  License: [Creative Commons 0](http://creativecommons.org/publicdomain/zero/1.0/)
+
 Hosting Infrastructure: [Jon Gjengset](https://twitter.com/jonhoo/)
 
 Show Notes: Luuk van der Duim


### PR DESCRIPTION
Adds: 2025-05-26-accesskit-with-matt-campbell-and-arnold-loubriat.md

From here on I could use a hand to get this over the finish line. 

I finished editing the audio but I don't think I have access to where that goes? (I see people posting the audio to the discord channel.)

I did see a `YYYY-MM-DD-template.md` in the root of this repo, where is that for? Do I need to fill that out still?
Also I wonder  what I have to do with the scripts that would provide transcripts - are these automatically run?

Thanks in advance.
