### PR TITLE
Move back to upstream Python

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -144,11 +144,6 @@ jobs:
     - name: Grab feed validator
       run: |
         git clone https://github.com/w3c/feedvalidator.git
-    - uses: actions/setup-python@v4
-      with:
-        # https://github.com/w3c/feedvalidator/issues/142
-        python-version: '3.12'
-        cache: 'pip'
     - name: Validate feed
       run: |
         # Fix Ubuntu MIME type for RSS


### PR DESCRIPTION
The w3c validator should now support newer Pyton